### PR TITLE
buffers: Move assignment operator implicitly deleted

### DIFF
--- a/dev/restinio/buffers.hpp
+++ b/dev/restinio/buffers.hpp
@@ -309,7 +309,7 @@ struct sendfile_write_operation_t : public writable_base_t
 		sendfile_write_operation_t( const sendfile_write_operation_t & ) = delete;
 		sendfile_write_operation_t & operator = ( const sendfile_write_operation_t & ) = delete;
 		sendfile_write_operation_t( sendfile_write_operation_t && ) = default;
-		sendfile_write_operation_t & operator = ( sendfile_write_operation_t && ) = default;
+		sendfile_write_operation_t & operator = ( sendfile_write_operation_t && ) = delete;
 
 		/*!
 			@name An implementation of writable_base_t interface.


### PR DESCRIPTION
Declaring this as `= default` is misleading as the operator is deleted.

Warns on clang 8 with `-Wdefaulted-function-deleted`:
```
.../restinio/dev/restinio/buffers.hpp:312:32: fatal error: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
                sendfile_write_operation_t & operator = ( sendfile_write_operation_t && ) = default;
                                             ^
.../restinio/dev/restinio/buffers.hpp:300:37: note: move assignment operator of 'sendfile_write_operation_t' is implicitly deleted because base class 'restinio::impl::writable_base_t' has a deleted move assignment operator
struct sendfile_write_operation_t : public writable_base_t
                                    ^
.../restinio/dev/restinio/buffers.hpp:49:21: note: 'operator=' has been explicitly marked deleted here
                writable_base_t & operator = ( writable_base_t && ) = delete;
                                  ^
```