### PR TITLE
tls_socket: add set_verify_mode & set_verify_callback

### DIFF
--- a/dev/restinio/impl/tls_socket.hpp
+++ b/dev/restinio/impl/tls_socket.hpp
@@ -123,6 +123,20 @@ class tls_socket_t
 
 		template< typename... Args >
 		auto
+		set_verify_mode( Args &&... args )
+		{
+			return m_socket->set_verify_mode( std::forward< Args >( args )... );
+		}
+
+		template< typename... Args >
+		auto
+		set_verify_callback( Args &&... args )
+		{
+			return m_socket->set_verify_callback( std::forward< Args >( args )... );
+		}
+
+		template< typename... Args >
+		auto
 		async_handshake( Args &&... args )
 		{
 			return m_socket->async_handshake( std::forward< Args >( args )... );


### PR DESCRIPTION
Fixes #39. These functions serves to make the SSL verification with Asio:
http://think-async.com/Asio/asio-1.12.2/doc/asio/reference/ssl__rfc2818_verification.html