### PR TITLE
Code Quality Fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/dev/test/sendfile/f1.txt text eol=lf
+/dev/test/sendfile/f2.txt text eol=lf
+/dev/test/sendfile/f3.txt text eol=lf

--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -64,6 +64,9 @@ IF (RESTINIO_MASTER_PROJECT)
 	IF (RESTINIO_FIND_DEPS)
 		# Require necessary packages.
 
+		# Catch2
+		find_package(Catch2 CONFIG REQUIRED)
+
 		# HTTP parser
 		find_package(unofficial-http-parser CONFIG REQUIRED)
 
@@ -71,6 +74,8 @@ IF (RESTINIO_MASTER_PROJECT)
 		find_package(fmt REQUIRED)
 	ELSE ()
 		# Add necessary dependecies.
+
+		include_directories("${CMAKE_SOURCE_DIR}/clara")
 
 		# HTTP parser
 		add_subdirectory(nodejs/http_parser)

--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -65,7 +65,7 @@ IF (RESTINIO_MASTER_PROJECT)
 		# Require necessary packages.
 
 		# HTTP parser
-		# http_parser is linked as raw static lib file.
+		find_package(unofficial-http-parser CONFIG REQUIRED)
 
 		# fmtlib
 		find_package(fmt REQUIRED)

--- a/dev/benches/common_args/app_args.hpp
+++ b/dev/benches/common_args/app_args.hpp
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-#include <clara/clara.hpp>
+#include <clara.hpp>
 #include <fmt/format.h>
 
 //

--- a/dev/restinio/CMakeLists.txt
+++ b/dev/restinio/CMakeLists.txt
@@ -97,6 +97,7 @@ SET(RESTINIO_HEADERS_ALL
 	uri_helpers.hpp
 	value_or.hpp
 	variant.hpp
+	tls_fwd.hpp
 	impl/acceptor.hpp
 	impl/connection_base.hpp
 	impl/connection.hpp

--- a/dev/sample/async_handling_with_sobjectizer/main.cpp
+++ b/dev/sample/async_handling_with_sobjectizer/main.cpp
@@ -17,7 +17,7 @@ struct timeout_elapsed
 	std::chrono::milliseconds m_pause;
 };
 
-void processing_thread_func(so_5::mchain_t req_ch)
+void processing_thread_func(const so_5::mchain_t& req_ch)
 {
 	// The stuff necessary for random pause generation.
 	std::random_device rd;
@@ -38,7 +38,7 @@ void processing_thread_func(so_5::mchain_t req_ch)
 
 		// Read and handle handle_request messages from req_ch.
 		case_(req_ch,
-			[&](handle_request cmd) {
+			[&](const handle_request& cmd) {
 				// Generate a random pause for processing of that request.
 				const std::chrono::milliseconds pause{pause_generator(generator)};
 
@@ -54,7 +54,7 @@ void processing_thread_func(so_5::mchain_t req_ch)
 
 		// Read and handle timeout_elapsed messages from delayed_ch.
 		case_(delayed_ch,
-			[](timeout_elapsed cmd) {
+			[](const timeout_elapsed& cmd) {
 				// Now we can create an actual response to the request.
 				cmd.m_req->create_response()
 						.set_body("Hello, World! (pause:"

--- a/dev/sample/compression/main.cpp
+++ b/dev/sample/compression/main.cpp
@@ -8,7 +8,7 @@
 #include <restinio/all.hpp>
 #include <restinio/transforms/zlib.hpp>
 
-#include <clara/clara.hpp>
+#include <clara.hpp>
 #include <fmt/format.h>
 
 //

--- a/dev/sample/compression/main.cpp
+++ b/dev/sample/compression/main.cpp
@@ -124,7 +124,7 @@ void setup_resp_headers( Resp & resp )
 }
 
 auto make_resp_for_small_count(
-	restinio::request_handle_t req,
+	const restinio::request_handle_t& req,
 	const restinio::query_string_params_t & qp,
 	std::size_t count )
 {
@@ -145,7 +145,7 @@ auto make_resp_for_small_count(
 }
 
 auto make_resp_for_large_count(
-	restinio::request_handle_t req,
+	const restinio::request_handle_t& req,
 	const restinio::query_string_params_t & qp,
 	std::size_t count )
 {
@@ -177,7 +177,7 @@ auto make_router()
 
 	router->http_get(
 		R"-(/rand/nums)-",
-		[ & ]( restinio::request_handle_t req, auto ){
+		[ & ]( const restinio::request_handle_t& req, auto ){
 
 			const auto qp = restinio::parse_query( req->header().query() );
 			const std::size_t count = restinio::value_or( qp, "count", 100u );
@@ -185,12 +185,12 @@ auto make_router()
 			if( count < count_threshold )
 			{
 				// Not to much data to be served in response.
-				return make_resp_for_small_count( std::move( req ), qp, count );
+				return make_resp_for_small_count( req , qp, count );
 			}
 			else
 			{
 				// The data is big enough to use chunked encoding.
-				return make_resp_for_large_count( std::move( req ), qp, count );
+				return make_resp_for_large_count( req , qp, count );
 			}
 		} );
 

--- a/dev/sample/connection_state/main.cpp
+++ b/dev/sample/connection_state/main.cpp
@@ -40,7 +40,7 @@ public:
 };
 
 // This is the request handler.
-restinio::request_handling_status_t handler( restinio::request_handle_t req )
+restinio::request_handling_status_t handler( const restinio::request_handle_t& req )
 {
 	if( restinio::http_method_get() == req->header().method() &&
 		req->header().request_target() == "/" )

--- a/dev/sample/custom_buffer/main.cpp
+++ b/dev/sample/custom_buffer/main.cpp
@@ -39,7 +39,7 @@ custom_buffer_t make_resp_body()
 }
 
 // Create request handler.
-restinio::request_handling_status_t handler( restinio::request_handle_t req )
+restinio::request_handling_status_t handler( const restinio::request_handle_t& req )
 {
 	if( restinio::http_method_get() == req->header().method() &&
 		req->header().request_target() == "/" )

--- a/dev/sample/decompression/main.cpp
+++ b/dev/sample/decompression/main.cpp
@@ -8,7 +8,7 @@
 #include <restinio/all.hpp>
 #include <restinio/transforms/zlib.hpp>
 
-#include <clara/clara.hpp>
+#include <clara.hpp>
 #include <fmt/format.h>
 
 //

--- a/dev/sample/decompression/main.cpp
+++ b/dev/sample/decompression/main.cpp
@@ -75,7 +75,7 @@ auto make_router()
 
 	router->http_post(
 		R"-(/)-",
-		[ & ]( restinio::request_handle_t req, auto ){
+		[ & ]( const restinio::request_handle_t& req, auto ){
 
 			return req->create_response()
 				.append_header( "Server", "RESTinio" )

--- a/dev/sample/express_router/main.cpp
+++ b/dev/sample/express_router/main.cpp
@@ -2,9 +2,6 @@
 
 #include <restinio/all.hpp>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-
 #include <json_dto/pub.hpp>
 
 struct book_t
@@ -39,7 +36,7 @@ using router_t = rr::express_router_t<>;
 class books_handler_t
 {
 public :
-	books_handler_t( book_collection_t & books )
+	explicit books_handler_t( book_collection_t & books )
 		:	m_books( books )
 	{}
 
@@ -47,7 +44,7 @@ public :
 	books_handler_t( books_handler_t && ) = delete;
 
 	auto on_books_list(
-		restinio::request_handle_t req, rr::route_params_t ) const
+		const restinio::request_handle_t& req, rr::route_params_t ) const
 	{
 		auto resp = init_resp( req->create_response() );
 
@@ -66,7 +63,7 @@ public :
 	}
 
 	auto on_book_get(
-		restinio::request_handle_t req, rr::route_params_t params )
+		const restinio::request_handle_t& req, rr::route_params_t params )
 	{
 		const auto booknum = restinio::cast_to< std::uint32_t >( params[ "booknum" ] );
 
@@ -89,7 +86,7 @@ public :
 	}
 
 	auto on_author_get(
-		restinio::request_handle_t req, rr::route_params_t params )
+		const restinio::request_handle_t& req, rr::route_params_t params )
 	{
 		auto resp = init_resp( req->create_response() );
 		try
@@ -117,7 +114,7 @@ public :
 	}
 
 	auto on_new_book(
-		restinio::request_handle_t req, rr::route_params_t )
+		const restinio::request_handle_t& req, rr::route_params_t )
 	{
 		auto resp = init_resp( req->create_response() );
 
@@ -135,7 +132,7 @@ public :
 	}
 
 	auto on_book_update(
-		restinio::request_handle_t req, rr::route_params_t params )
+		const restinio::request_handle_t& req, rr::route_params_t params )
 	{
 		const auto booknum = restinio::cast_to< std::uint32_t >( params[ "booknum" ] );
 
@@ -164,7 +161,7 @@ public :
 	}
 
 	auto on_book_delete(
-		restinio::request_handle_t req, rr::route_params_t params )
+		const restinio::request_handle_t& req, rr::route_params_t params )
 	{
 		const auto booknum = restinio::cast_to< std::uint32_t >( params[ "booknum" ] );
 

--- a/dev/sample/express_router_tutorial/main.cpp
+++ b/dev/sample/express_router_tutorial/main.cpp
@@ -1,10 +1,8 @@
 #include <iostream>
-#include <sstream>
 
 #include <restinio/all.hpp>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 
 namespace rr = restinio::router;
@@ -93,7 +91,7 @@ auto server_handler()
 			// Query params.
 			const auto qp = restinio::parse_query( req->header().query() );
 
-			if( 0 == qp.size() )
+			if( qp.empty() )
 			{
 				sout << "No query parameters.";
 			}

--- a/dev/sample/hello_world/main.cpp
+++ b/dev/sample/hello_world/main.cpp
@@ -2,9 +2,6 @@
 
 #include <restinio/all.hpp>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-
 template < typename RESP >
 RESP
 init_resp( RESP resp )

--- a/dev/sample/hello_world_basic/main.cpp
+++ b/dev/sample/hello_world_basic/main.cpp
@@ -3,7 +3,7 @@
 #include <restinio/all.hpp>
 
 // Create request handler.
-restinio::request_handling_status_t handler( restinio::request_handle_t req )
+restinio::request_handling_status_t handler( const restinio::request_handle_t& req )
 {
 	if( restinio::http_method_get() == req->header().method() &&
 		req->header().request_target() == "/" )

--- a/dev/sample/hello_world_delayed/main.cpp
+++ b/dev/sample/hello_world_delayed/main.cpp
@@ -5,7 +5,7 @@
 // Actual request handler.
 restinio::request_handling_status_t handler(
 	restinio::asio_ns::io_context & ioctx,
-	restinio::request_handle_t req)
+	const restinio::request_handle_t& req)
 {
 	if( restinio::http_method_get() == req->header().method() &&
 		req->header().request_target() == "/" )

--- a/dev/sample/hello_world_sendfile/main.cpp
+++ b/dev/sample/hello_world_sendfile/main.cpp
@@ -7,7 +7,7 @@
 #include <restinio/all.hpp>
 
 #include <fmt/format.h>
-#include <clara/clara.hpp>
+#include <clara.hpp>
 
 //
 // app_args_t

--- a/dev/sample/hello_world_sendfile_https/main.cpp
+++ b/dev/sample/hello_world_sendfile_https/main.cpp
@@ -9,7 +9,7 @@
 
 #include <fmt/format.h>
 
-#include <clara/clara.hpp>
+#include <clara.hpp>
 
 //
 // app_args_t

--- a/dev/sample/hello_world_sendfile_w32_unicode/main.cpp
+++ b/dev/sample/hello_world_sendfile_w32_unicode/main.cpp
@@ -7,7 +7,7 @@
 #include <restinio/all.hpp>
 
 #include <fmt/format.h>
-#include <clara/clara.hpp>
+#include <clara.hpp>
 
 //
 // app_args_t

--- a/dev/sample/ip_blocker/main.cpp
+++ b/dev/sample/ip_blocker/main.cpp
@@ -75,7 +75,7 @@ public:
 // Actual request handler.
 restinio::request_handling_status_t handler(
 	restinio::asio_ns::io_context & ioctx,
-	restinio::request_handle_t req)
+	const restinio::request_handle_t& req)
 {
 	if( restinio::http_method_get() == req->header().method() &&
 		req->header().request_target() == "/" )

--- a/dev/sample/notificators/main.cpp
+++ b/dev/sample/notificators/main.cpp
@@ -35,7 +35,7 @@ class a_req_handler_t final : public so_5::agent_t
 	public:
 		a_req_handler_t(
 			context_t ctx,
-			restinio::request_handle_t req )
+			const restinio::request_handle_t& req )
 			:	so_base_type_t{ std::move( ctx ) }
 			,	m_resp{ req->create_response< restinio::chunked_output_t >() }
 			,	m_part_it{ begin( g_response_parts ) }
@@ -43,7 +43,7 @@ class a_req_handler_t final : public so_5::agent_t
 			so_subscribe_self().event( &a_req_handler_t::evt_stream_next_chunk );
 		};
 
-		virtual void so_evt_start() override
+		void so_evt_start() override
 		{
 			// Set header and start response sending circle.
 
@@ -112,13 +112,13 @@ int main()
 				.port( 8080 )
 				.address( "localhost" )
 				.max_pipelined_requests( 4 )
-				.request_handler( [&]( restinio::request_handle_t req ){
+				.request_handler( [&]( const restinio::request_handle_t& req ){
 					sobj.environment()
 						.register_agent_as_coop(
 							so_5::autoname,
 							std::make_unique< a_req_handler_t >(
 								sobj.environment(),
-								std::move( req ) ) );
+								req ) );
 
 					return restinio::request_accepted();
 				} ) );

--- a/dev/sample/query_string_params/main.cpp
+++ b/dev/sample/query_string_params/main.cpp
@@ -3,7 +3,7 @@
 #include <restinio/all.hpp>
 
 // Create request handler.
-restinio::request_handling_status_t handler( restinio::request_handle_t req )
+restinio::request_handling_status_t handler( const restinio::request_handle_t& req )
 {
 	if( restinio::http_method_get() == req->header().method() )
 	{
@@ -13,7 +13,7 @@ restinio::request_handling_status_t handler( restinio::request_handle_t req )
 		// Query params.
 		const auto qp = restinio::parse_query( req->header().query() );
 
-		if( 0 == qp.size() )
+		if( qp.empty() )
 		{
 			sout << "No query parameters.";
 		}

--- a/dev/sample/run_existing_server/main.cpp
+++ b/dev/sample/run_existing_server/main.cpp
@@ -3,7 +3,7 @@
 #include <restinio/all.hpp>
 
 // Create request handler.
-restinio::request_handling_status_t handler( restinio::request_handle_t req )
+restinio::request_handling_status_t handler( const restinio::request_handle_t& req )
 {
 	if( restinio::http_method_get() == req->header().method() &&
 		req->header().request_target() == "/" )

--- a/dev/sample/run_for_minute/main.cpp
+++ b/dev/sample/run_for_minute/main.cpp
@@ -3,7 +3,7 @@
 #include <restinio/all.hpp>
 
 // Create request handler.
-restinio::request_handling_status_t handler( restinio::request_handle_t req )
+restinio::request_handling_status_t handler( const restinio::request_handle_t& req )
 {
 	if( restinio::http_method_get() == req->header().method() &&
 		req->header().request_target() == "/" )

--- a/dev/sample/sendfiles/main.cpp
+++ b/dev/sample/sendfiles/main.cpp
@@ -5,7 +5,6 @@
 
 #include <clara/clara.hpp>
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 const char *
 content_type_by_file_extention( const restinio::string_view_t & ext )

--- a/dev/sample/sendfiles/main.cpp
+++ b/dev/sample/sendfiles/main.cpp
@@ -3,7 +3,7 @@
 
 #include <restinio/all.hpp>
 
-#include <clara/clara.hpp>
+#include <clara.hpp>
 #include <fmt/format.h>
 
 const char *

--- a/dev/sample/tls_inspector/main.cpp
+++ b/dev/sample/tls_inspector/main.cpp
@@ -4,7 +4,6 @@
 #include <restinio/tls.hpp>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 class user_connections_t
 {
@@ -55,12 +54,12 @@ init_resp( RESP resp )
 	resp.append_header_date_field();
 
 	return resp;
-};
+}
 
 namespace rr = restinio::router;
 using router_t = rr::express_router_t<>;
 
-auto server_handler( user_connections_shptr_t user_connections )
+auto server_handler( const user_connections_shptr_t& user_connections )
 {
 	auto router = std::make_unique< router_t >();
 
@@ -168,7 +167,7 @@ std::string extract_user_name_from_client_certificate(
 class my_tls_inspector_t
 {
 public:
-	my_tls_inspector_t(
+	explicit my_tls_inspector_t(
 		user_connections_shptr_t user_connections )
 		:	m_user_connections{ std::move(user_connections) }
 	{}

--- a/dev/sample/using_external_io_context/main.cpp
+++ b/dev/sample/using_external_io_context/main.cpp
@@ -3,7 +3,7 @@
 #include <restinio/all.hpp>
 
 // Create request handler.
-auto create_request_handler( std::string tag )
+auto create_request_handler( const std::string& tag )
 {
 	return [tag]( auto req ) {
 			if( restinio::http_method_get() == req->header().method() &&

--- a/dev/sample/websocket/main.cpp
+++ b/dev/sample/websocket/main.cpp
@@ -4,7 +4,6 @@
 #include <restinio/websocket/websocket.hpp>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 namespace rr = restinio::router;
 using router_t = rr::express_router_t<>;

--- a/dev/sample/websocket_detailed/main.cpp
+++ b/dev/sample/websocket_detailed/main.cpp
@@ -4,7 +4,6 @@
 #include <restinio/websocket/websocket.hpp>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 using namespace std::chrono_literals;
 

--- a/dev/sample/websocket_wss/main.cpp
+++ b/dev/sample/websocket_wss/main.cpp
@@ -5,7 +5,6 @@
 #include <restinio/websocket/websocket.hpp>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 using router_t = restinio::router::express_router_t<>;
 

--- a/dev/test/catch_main/CMakeLists.txt
+++ b/dev/test/catch_main/CMakeLists.txt
@@ -1,4 +1,8 @@
 add_library(restinio_catch_main STATIC catch_main.cpp)
 add_library(restinio::catch_main ALIAS restinio_catch_main)
 
+if (RESTINIO_FIND_DEPS)
+    TARGET_LINK_LIBRARIES(restinio_catch_main Catch2::Catch2)
+endif()
+
 TARGET_INCLUDE_DIRECTORIES(restinio_catch_main PRIVATE ${CMAKE_SOURCE_DIR})

--- a/dev/test/from_string_bench/main.cpp
+++ b/dev/test/from_string_bench/main.cpp
@@ -139,7 +139,7 @@ cast_dataset_t< std::uint64_t > uints64_data;
 void
 init_datasets( size_t n )
 {
-	std::srand( std::time( nullptr ) );
+	std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	ints8_data = create_ints< std::int8_t >( n );
 	uints8_data = create_ints< std::uint8_t >( n );

--- a/dev/test/handle_requests/connection_state/main.cpp
+++ b/dev/test/handle_requests/connection_state/main.cpp
@@ -303,8 +303,13 @@ TEST_CASE( "connection state for WS" , "[connection_state][ws]" )
 
 
 								endpoint_value_ws = fmt::format( "{}", ws->remote_endpoint() );
-								// TODO: write close-message.
+
+								req->create_response()
+									.set_body("Closed!")
+									.done();
+								
 								ws->kill();
+								
 								return restinio::request_accepted();
 							}
 							catch( const std::exception & ex )

--- a/dev/test/handle_requests/ip_blocker/main.cpp
+++ b/dev/test/handle_requests/ip_blocker/main.cpp
@@ -13,7 +13,7 @@
 class blocker_t
 {
 	std::mutex m_lock;
-	int m_ordinal{};
+	unsigned m_ordinal{};
 
 public :
 

--- a/dev/test/handle_requests/notificators/main.cpp
+++ b/dev/test/handle_requests/notificators/main.cpp
@@ -82,7 +82,7 @@ TEST_CASE( "notificators simple 2" , "[user_controlled_output]" )
 				.port( utest_default_port() )
 				.address( "127.0.0.1" )
 				.request_handler(
-					[&]( restinio::request_handle_t req ){
+					[&]( const restinio::request_handle_t& req ){
 						using output_type_t = restinio::user_controlled_output_t;
 						auto resp = req->create_response< output_type_t >();
 
@@ -136,7 +136,7 @@ TEST_CASE( "notificators simple 3" , "[chunked_output]" )
 				.port( utest_default_port() )
 				.address( "127.0.0.1" )
 				.request_handler(
-					[&]( restinio::request_handle_t req ){
+					[&]( const restinio::request_handle_t& req ){
 						using output_type_t = restinio::chunked_output_t;
 						auto resp = req->create_response< output_type_t >();
 
@@ -200,7 +200,7 @@ TEST_CASE( "notificators user_controlled_output flush-flush" , "[user_controlled
 				.port( utest_default_port() )
 				.address( "127.0.0.1" )
 				.request_handler(
-					[&]( restinio::request_handle_t req ){
+					[&]( const restinio::request_handle_t& req ){
 						using output_type_t = restinio::user_controlled_output_t;
 						auto resp = req->create_response< output_type_t >();
 
@@ -262,7 +262,7 @@ TEST_CASE( "notificators chunked_output flush-flush" , "[chunked_output][flush]"
 				.port( utest_default_port() )
 				.address( "127.0.0.1" )
 				.request_handler(
-					[&]( restinio::request_handle_t req ){
+					[&]( const restinio::request_handle_t& req ){
 						using output_type_t = restinio::chunked_output_t;
 						auto resp = req->create_response< output_type_t >();
 
@@ -328,7 +328,7 @@ TEST_CASE( "notificators error" , "[error]" )
 				.port( utest_default_port() )
 				.address( "127.0.0.1" )
 				.request_handler(
-					[&]( restinio::request_handle_t req ){
+					[&]( const restinio::request_handle_t& req ){
 						auto resp = req->create_response();
 
 						resp
@@ -554,7 +554,7 @@ TEST_CASE( "notificators throw 1" , "[error][throw]" )
 				.address( "127.0.0.1" )
 				.max_pipelined_requests( 2 )
 				.request_handler(
-					[&]( restinio::request_handle_t req ){
+					[&]( const restinio::request_handle_t& req ){
 						auto resp = req->create_response();
 
 						resp

--- a/dev/test/handle_requests/output_and_buffers/const_buffer.cpp
+++ b/dev/test/handle_requests/output_and_buffers/const_buffer.cpp
@@ -297,7 +297,7 @@ TEST_CASE(
 				.port( utest_default_port() )
 				.address( "127.0.0.1" )
 				.request_handler(
-					[ = ]( restinio::request_handle_t req ){
+					[ = ]( const restinio::request_handle_t& req ){
 						using output_type_t = restinio::user_controlled_output_t;
 
 						return
@@ -355,7 +355,7 @@ TEST_CASE(
 				.port( utest_default_port() )
 				.address( "127.0.0.1" )
 				.request_handler(
-					[ = ]( restinio::request_handle_t req ){
+					[ = ]( const restinio::request_handle_t& req ){
 						using output_type_t = restinio::user_controlled_output_t;
 
 						auto resp = req->create_response< output_type_t >();
@@ -414,7 +414,7 @@ TEST_CASE(
 				.port( utest_default_port() )
 				.address( "127.0.0.1" )
 				.request_handler(
-					[ = ]( restinio::request_handle_t req ){
+					[ = ]( const restinio::request_handle_t& req ){
 						using output_type_t = restinio::user_controlled_output_t;
 
 						auto resp = req->create_response< output_type_t >();
@@ -483,7 +483,7 @@ TEST_CASE(
 				.port( utest_default_port() )
 				.address( "127.0.0.1" )
 				.request_handler(
-					[ = ]( restinio::request_handle_t req ){
+					[ = ]( const restinio::request_handle_t& req ){
 						using output_type_t = restinio::user_controlled_output_t;
 
 						auto resp = req->create_response< output_type_t >();
@@ -604,7 +604,7 @@ TEST_CASE(
 				.port( utest_default_port() )
 				.address( "127.0.0.1" )
 				.request_handler(
-					[ = ]( restinio::request_handle_t req ){
+					[ = ]( const restinio::request_handle_t& req ){
 						using output_type_t = restinio::chunked_output_t;
 
 						auto resp = req->create_response< output_type_t >();

--- a/dev/test/handle_requests/remote_endpoint/main.cpp
+++ b/dev/test/handle_requests/remote_endpoint/main.cpp
@@ -105,8 +105,13 @@ TEST_CASE( "remote_endpoint for WS" , "[remote_endpoint][ws]" )
 
 
 								endpoint_value_ws = fmt::format( "{}", ws->remote_endpoint() );
-								// TODO: write close-message.
+								
+								req->create_response()
+									.set_body("Closed!")
+									.done();
+
 								ws->kill();
+
 								return restinio::request_accepted();
 							}
 							catch( const std::exception & ex )

--- a/dev/test/handle_requests/remote_endpoint/main.cpp
+++ b/dev/test/handle_requests/remote_endpoint/main.cpp
@@ -64,7 +64,7 @@ TEST_CASE( "remote_endpoint extraction" , "[remote_endpoint]" )
 
 	other_thread.stop_and_join();
 
-	REQUIRE( "" != endpoint_value );
+	REQUIRE( !endpoint_value.empty() );
 }
 
 
@@ -100,8 +100,8 @@ TEST_CASE( "remote_endpoint for WS" , "[remote_endpoint][ws]" )
 									rws::upgrade< traits_t >(
 										*req,
 										rws::activation_t::immediate,
-										[]( rws::ws_handle_t,
-											rws::message_handle_t ){} );
+										[]( const rws::ws_handle_t&,
+											const rws::message_handle_t& ){} );
 
 
 								endpoint_value_ws = fmt::format( "{}", ws->remote_endpoint() );
@@ -139,6 +139,6 @@ TEST_CASE( "remote_endpoint for WS" , "[remote_endpoint][ws]" )
 
 	other_thread.stop_and_join();
 
-	REQUIRE( "" != endpoint_value );
+	REQUIRE( !endpoint_value.empty() );
 	REQUIRE( endpoint_value == endpoint_value_ws );
 }

--- a/dev/test/handle_requests/slow_transmit/main.cpp
+++ b/dev/test/handle_requests/slow_transmit/main.cpp
@@ -73,7 +73,7 @@ TEST_CASE( "Slow transmit" , "[slow_trunsmit]" )
 			std::this_thread::sleep_for( std::chrono::milliseconds( 2 ) );
 		}
 
-		std::array< char, 1024 > data;
+		std::array< char, 1024 > data{};
 
 		socket.async_read_some(
 			restinio::asio_ns::buffer( data.data(), data.size() ),

--- a/dev/test/handle_requests/throw_exception/main.cpp
+++ b/dev/test/handle_requests/throw_exception/main.cpp
@@ -58,7 +58,7 @@ TEST_CASE( "Throw exception" , "[exception]" )
 			restinio::asio_ns::write( socket, restinio::asio_ns::buffer( request ) )
 			);
 
-		std::array< char, 64 > data;
+		std::array< char, 64 > data{};
 		restinio::asio_ns::error_code error;
 
 		size_t length = // sock.read_some(restinio::asio_ns::buffer(data), error);

--- a/dev/test/handle_requests/timeouts/main.cpp
+++ b/dev/test/handle_requests/timeouts/main.cpp
@@ -59,7 +59,7 @@ TEST_CASE( "Timeout on reading requests" , "[timeout][read]" )
 		do_with_socket( [ & ]( auto & socket, auto & /*io_context*/ ){
 			std::this_thread::sleep_for( std::chrono::milliseconds( 6 ) );
 
-			std::array< char, 64 > data;
+			std::array< char, 64 > data{};
 
 			restinio::asio_ns::error_code error;
 
@@ -83,7 +83,7 @@ TEST_CASE( "Timeout on reading requests" , "[timeout][read]" )
 
 			std::this_thread::sleep_for( std::chrono::milliseconds( 6 ) );
 
-			std::array< char, 64 > data;
+			std::array< char, 64 > data{};
 			restinio::asio_ns::error_code error;
 
 			size_t length = // sock.read_some(asio::buffer(data), error);
@@ -112,7 +112,7 @@ TEST_CASE( "Timeout on reading requests" , "[timeout][read]" )
 
 			std::this_thread::sleep_for( std::chrono::milliseconds( 6 ) );
 
-			std::array< char, 64 > data;
+			std::array< char, 64 > data{};
 			restinio::asio_ns::error_code error;
 
 			size_t length = // sock.read_some(asio::buffer(data), error);
@@ -171,7 +171,7 @@ TEST_CASE( "Timeout on handling request" , "[timeout][handle_request]" )
 			restinio::asio_ns::write( socket, restinio::asio_ns::buffer( request ) )
 			);
 
-		std::array< char, 1024 > data;
+		std::array< char, 1024 > data{};
 
 		socket.async_read_some(
 			restinio::asio_ns::buffer( data ),

--- a/dev/test/router/cmp_router_bench/main.cpp
+++ b/dev/test/router/cmp_router_bench/main.cpp
@@ -6,7 +6,7 @@
 
 #include <restinio/all.hpp>
 
-#include <clara/clara.hpp>
+#include <clara.hpp>
 #include <fmt/format.h>
 
 #include "route_parser.hpp"

--- a/dev/test/router/express_router_bench/main.cpp
+++ b/dev/test/router/express_router_bench/main.cpp
@@ -6,7 +6,7 @@
 
 #include <restinio/all.hpp>
 
-#include <clara/clara.hpp>
+#include <clara.hpp>
 #include <fmt/format.h>
 
 #ifndef RESTINIO_EXPRESS_ROUTER_BENCH_APP_TITLE

--- a/dev/test/to_lower_bench/main.cpp
+++ b/dev/test/to_lower_bench/main.cpp
@@ -387,7 +387,7 @@ run_bench( const std::string & tag, LAMBDA lambda )
 int
 main()
 {
-	std::srand( std::time( nullptr ) );
+	std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	const auto str_set_1 = create_test_strings();
 	const auto str_set_2 = create_test_strings();

--- a/dev/test/transforms/zlib/main.cpp
+++ b/dev/test/transforms/zlib/main.cpp
@@ -181,7 +181,7 @@ TEST_CASE( "deflate" , "[zlib][compress][decompress][deflate]" )
 {
 	namespace rtz = restinio::transforms::zlib;
 
-	std::srand( std::time( nullptr ) );
+    std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	{
 		rtz::zlib_t zc{ rtz::make_deflate_compress_params() };
@@ -304,7 +304,7 @@ TEST_CASE( "gzip" , "[zlib][compress][decompress][gzip]" )
 {
 	namespace rtz = restinio::transforms::zlib;
 
-	std::srand( std::time( nullptr ) );
+    std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	{
 		rtz::zlib_t zc{ rtz::make_gzip_compress_params() };
@@ -427,7 +427,7 @@ TEST_CASE( "identity" , "[zlib][identity]" )
 {
 	namespace rtz = restinio::transforms::zlib;
 
-	std::srand( std::time( nullptr ) );
+    std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	{
 		rtz::zlib_t zc{ rtz::make_identity_params() };
@@ -484,7 +484,7 @@ TEST_CASE( "complete" , "[zlib][compress][decompress][commplete]" )
 {
 	namespace rtz = restinio::transforms::zlib;
 
-	std::srand( std::time( nullptr ) );
+    std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	{
 		rtz::zlib_t zc{ rtz::make_gzip_compress_params() };
@@ -542,7 +542,7 @@ TEST_CASE( "take output" , "[zlib][compress][decompress][output]" )
 {
 	namespace rtz = restinio::transforms::zlib;
 
-	std::srand( std::time( nullptr ) );
+	std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	{
 		rtz::zlib_t zc{ rtz::make_gzip_compress_params() };
@@ -628,7 +628,7 @@ TEST_CASE( "write check input size" , "[zlib][write][large input]" )
 {
 	namespace rtz = restinio::transforms::zlib;
 
-	std::srand( std::time( nullptr ) );
+	std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	if( sizeof( restinio::string_view_t::size_type ) == 8 )
 	{

--- a/dev/test/transforms/zlib_body_appender/main.cpp
+++ b/dev/test/transforms/zlib_body_appender/main.cpp
@@ -246,7 +246,7 @@ TEST_CASE( "user_controlled_output" , "[zlib][body_appender][user_controlled_out
 
 	router->http_get(
 		R"-(/deflate/:level(-?\d+))-",
-		[ & ]( restinio::request_handle_t req, auto params ){
+		[ & ]( const restinio::request_handle_t& req, auto params ){
 				auto resp = req->create_response< restinio::user_controlled_output_t >();
 
 				resp
@@ -277,7 +277,7 @@ TEST_CASE( "user_controlled_output" , "[zlib][body_appender][user_controlled_out
 
 	router->http_get(
 		R"-(/gzip/:level(-?\d+))-",
-		[ & ]( restinio::request_handle_t req, auto params ){
+		[ & ]( const restinio::request_handle_t& req, auto params ){
 				auto resp = req->create_response< restinio::user_controlled_output_t >();
 
 				resp
@@ -307,7 +307,7 @@ TEST_CASE( "user_controlled_output" , "[zlib][body_appender][user_controlled_out
 
 	router->http_get(
 		R"-(/identity)-",
-		[ & ]( restinio::request_handle_t req, auto ){
+		[ & ]( const restinio::request_handle_t& req, auto ){
 				auto resp = req->create_response< restinio::user_controlled_output_t >();
 
 				resp
@@ -533,7 +533,7 @@ TEST_CASE( "chunked_output" , "[zlib][body_appender][chunked_output]" )
 
 	router->http_get(
 		R"-(/deflate/:level(-?\d+))-",
-		[ & ]( restinio::request_handle_t req, auto params ){
+		[ & ]( const restinio::request_handle_t& req, auto params ){
 				auto resp = req->create_response< restinio::chunked_output_t >();
 
 				resp
@@ -566,7 +566,7 @@ TEST_CASE( "chunked_output" , "[zlib][body_appender][chunked_output]" )
 
 	router->http_get(
 		R"-(/gzip/:level(-?\d+))-",
-		[ & ]( restinio::request_handle_t req, auto params ){
+		[ & ]( const restinio::request_handle_t& req, auto params ){
 				auto resp = req->create_response< restinio::chunked_output_t >();
 
 				resp
@@ -599,7 +599,7 @@ TEST_CASE( "chunked_output" , "[zlib][body_appender][chunked_output]" )
 
 	router->http_get(
 		R"-(/identity)-",
-		[ & ]( restinio::request_handle_t req, auto ){
+		[ & ]( const restinio::request_handle_t& req, auto ){
 				auto resp = req->create_response< restinio::chunked_output_t >();
 
 				resp

--- a/dev/test/transforms/zlib_body_appender/main.cpp
+++ b/dev/test/transforms/zlib_body_appender/main.cpp
@@ -18,7 +18,7 @@
 
 TEST_CASE( "restinio_controlled_output" , "[zlib][body_appender][restinio_controlled_output]" )
 {
-	std::srand( std::time( nullptr ) );
+	std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	const auto response_body = create_random_text( 128 * 1024, 16 );
 
@@ -234,7 +234,7 @@ TEST_CASE( "restinio_controlled_output" , "[zlib][body_appender][restinio_contro
 
 TEST_CASE( "user_controlled_output" , "[zlib][body_appender][user_controlled_output]" )
 {
-	std::srand( std::time( nullptr ) );
+	std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	const auto response_body = create_random_text( 128 * 1024, 16 );
 
@@ -521,7 +521,7 @@ TEST_CASE( "user_controlled_output" , "[zlib][body_appender][user_controlled_out
 
 TEST_CASE( "chunked_output" , "[zlib][body_appender][chunked_output]" )
 {
-	std::srand( std::time( nullptr ) );
+	std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	const auto response_body = create_random_text( 128 * 1024, 16 );
 

--- a/dev/test/transforms/zlib_body_handler/main.cpp
+++ b/dev/test/transforms/zlib_body_handler/main.cpp
@@ -18,7 +18,7 @@
 
 TEST_CASE( "body_handler" , "[zlib][body_handler]" )
 {
-	std::srand( std::time( nullptr ) );
+	std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	const auto response_body = create_random_text( 128 * 1024, 16 );
 
@@ -128,7 +128,7 @@ TEST_CASE( "body_handler" , "[zlib][body_handler]" )
 
 TEST_CASE( "body_handler void return" , "[zlib][body_handler][void-return]" )
 {
-	std::srand( std::time( nullptr ) );
+	std::srand( static_cast<unsigned int>(std::time( nullptr )) );
 
 	const auto response_body = create_random_text( 1024, 16 );
 

--- a/dev/test/transforms/zlib_body_handler/main.cpp
+++ b/dev/test/transforms/zlib_body_handler/main.cpp
@@ -140,7 +140,7 @@ TEST_CASE( "body_handler void return" , "[zlib][body_handler][void-return]" )
 
 	router->http_post(
 		"/",
-		[ & ]( restinio::request_handle_t req, auto ){
+		[ & ]( const restinio::request_handle_t& req, auto ){
 			auto resp = req->create_response();
 
 			resp.append_header( restinio::http_field::server, "RESTinio" )

--- a/dev/test/uri_helpers/main.cpp
+++ b/dev/test/uri_helpers/main.cpp
@@ -20,7 +20,7 @@ TEST_CASE( "Escape percent encoding" , "[escape][percent_encoding]" )
 			"abcdefghijklmnopqrstuvwxyz"
 			"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 			"-~._" };
-		const std::string expected_result{ input_data };
+		const std::string& expected_result{ input_data };
 
 		std::string result;
 
@@ -56,7 +56,7 @@ TEST_CASE( "Unescape percent encoding" , "[unescape][percent_encoding]" )
 			"abcdefghijklmnopqrstuvwxyz"
 			"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 			"-~._" };
-		const std::string expected_result{ input_data };
+		const std::string& expected_result{ input_data };
 
 		std::string result;
 

--- a/dev/test/websocket/parser/main.cpp
+++ b/dev/test/websocket/parser/main.cpp
@@ -39,45 +39,45 @@ TEST_CASE( "Validate parser implementation details" , "[websocket][parser][impl]
 TEST_CASE( "Validate websocket message details constructing" , "[websocket][parser][message]" )
 {
 	message_details_t m0;
-	REQUIRE( m0.m_final_flag == true );
-	REQUIRE( m0.m_rsv1_flag == false );
-	REQUIRE( m0.m_rsv2_flag == false );
-	REQUIRE( m0.m_rsv3_flag == false );
+	REQUIRE(m0.m_final_flag);
+	REQUIRE(!m0.m_rsv1_flag);
+	REQUIRE(!m0.m_rsv2_flag);
+	REQUIRE(!m0.m_rsv3_flag);
 	REQUIRE( m0.m_opcode == opcode_t::continuation_frame );
-	REQUIRE( m0.m_mask_flag == false );
+	REQUIRE(!m0.m_mask_flag);
 	REQUIRE( m0.m_payload_len == 0 );
 	REQUIRE( m0.m_ext_payload_len == 0 );
 	REQUIRE( m0.m_masking_key == 0 );
 
 	message_details_t m1{not_final_frame, opcode_t::text_frame, 125};
-	REQUIRE( m1.m_final_flag == false );
-	REQUIRE( m1.m_rsv1_flag == false );
-	REQUIRE( m1.m_rsv2_flag == false );
-	REQUIRE( m1.m_rsv3_flag == false );
+	REQUIRE(!m1.m_final_flag);
+	REQUIRE(!m1.m_rsv1_flag);
+	REQUIRE(!m1.m_rsv2_flag);
+	REQUIRE(!m1.m_rsv3_flag);
 	REQUIRE( m1.m_opcode == opcode_t::text_frame );
-	REQUIRE( m1.m_mask_flag == false );
+	REQUIRE(!m1.m_mask_flag);
 	REQUIRE( m1.m_payload_len == 125 );
 	REQUIRE( m1.m_ext_payload_len == 0 );
 	REQUIRE( m1.m_masking_key == 0 );
 
 	message_details_t m2{final_frame, opcode_t::binary_frame, 126};
-	REQUIRE( m2.m_final_flag == true );
-	REQUIRE( m2.m_rsv1_flag == false );
-	REQUIRE( m2.m_rsv2_flag == false );
-	REQUIRE( m2.m_rsv3_flag == false );
+	REQUIRE(m2.m_final_flag);
+	REQUIRE(!m2.m_rsv1_flag);
+	REQUIRE(!m2.m_rsv2_flag);
+	REQUIRE(!m2.m_rsv3_flag);
 	REQUIRE( m2.m_opcode == opcode_t::binary_frame );
-	REQUIRE( m2.m_mask_flag == false );
+	REQUIRE(!m2.m_mask_flag);
 	REQUIRE( m2.m_payload_len == 126 );
 	REQUIRE( m2.m_ext_payload_len == 126 );
 	REQUIRE( m2.m_masking_key == 0 );
 
 	message_details_t m3{final_frame, opcode_t::binary_frame, 65536};
-	REQUIRE( m3.m_final_flag == true );
-	REQUIRE( m3.m_rsv1_flag == false );
-	REQUIRE( m3.m_rsv2_flag == false );
-	REQUIRE( m3.m_rsv3_flag == false );
+	REQUIRE(m3.m_final_flag);
+	REQUIRE(!m3.m_rsv1_flag);
+	REQUIRE(!m3.m_rsv2_flag);
+	REQUIRE(!m3.m_rsv3_flag);
 	REQUIRE( m3.m_opcode == opcode_t::binary_frame );
-	REQUIRE( m3.m_mask_flag == false );
+	REQUIRE(!m3.m_mask_flag);
 	REQUIRE( m3.m_payload_len == 127 );
 	REQUIRE( m3.m_ext_payload_len == 65536 );
 	REQUIRE( m3.m_masking_key == 0 );
@@ -104,12 +104,12 @@ TEST_CASE( "Reset parser" , "[websocket][parser][reset]" )
 	auto nparsed = parser.parser_execute( bin_data.data(), bin_data.size() );
 
 	REQUIRE( nparsed == 2 );
-	REQUIRE( parser.header_parsed() == true );
+	REQUIRE(parser.header_parsed());
 	auto ws_message_details = parser.current_message();
 
 	REQUIRE( ws_message_details.payload_len() == 5 );
 	parser.reset();
-	REQUIRE( parser.header_parsed() == false );
+	REQUIRE(!parser.header_parsed());
 	REQUIRE( parser.current_message().payload_len() == 0 );
 }
 
@@ -121,14 +121,14 @@ TEST_CASE( "Parse header (2 bytes only)" , "[websocket][parser][read]" )
 		auto nparsed = parser.parser_execute( bin_data.data(), bin_data.size() );
 
 		REQUIRE( nparsed == 2 );
-		REQUIRE( parser.header_parsed() == true );
+		REQUIRE(parser.header_parsed());
 
 		auto ws_message_details = parser.current_message();
 
-		REQUIRE( ws_message_details.m_final_flag == true );
-		REQUIRE( ws_message_details.m_rsv1_flag == false );
-		REQUIRE( ws_message_details.m_rsv2_flag == false );
-		REQUIRE( ws_message_details.m_rsv3_flag == false );
+		REQUIRE(ws_message_details.m_final_flag);
+		REQUIRE(!ws_message_details.m_rsv1_flag);
+		REQUIRE(!ws_message_details.m_rsv2_flag);
+		REQUIRE(!ws_message_details.m_rsv3_flag);
 		REQUIRE( ws_message_details.m_opcode == opcode_t::text_frame );
 		REQUIRE( ws_message_details.payload_len() == 5 );
 	}
@@ -213,7 +213,7 @@ TEST_CASE( "Parse header (2 bytes + 4 bytes masking key )" ,
 		ws_parser_t parser;
 		(void)parser.parser_execute( bin_data.data(), bin_data.size() );
 
-		REQUIRE( parser.current_message().m_mask_flag == true );
+		REQUIRE(parser.current_message().m_mask_flag);
 		REQUIRE( parser.current_message().m_masking_key == 0x37FA213D );
 	}
 }
@@ -227,14 +227,14 @@ TEST_CASE( "Parse simple message" , "[websocket][parser][read]" )
 	auto nparsed = parser.parser_execute( bin_data.data(), bin_data.size() );
 
 	REQUIRE( nparsed == 2 );
-	REQUIRE( parser.header_parsed() == true );
+	REQUIRE(parser.header_parsed());
 
 	auto ws_message_details = parser.current_message();
 
-	REQUIRE( ws_message_details.m_final_flag == true );
-	REQUIRE( ws_message_details.m_rsv1_flag == false );
-	REQUIRE( ws_message_details.m_rsv2_flag == false );
-	REQUIRE( ws_message_details.m_rsv3_flag == false );
+	REQUIRE( ws_message_details.m_final_flag );
+	REQUIRE(!ws_message_details.m_rsv1_flag);
+	REQUIRE(!ws_message_details.m_rsv2_flag);
+	REQUIRE(!ws_message_details.m_rsv3_flag);
 	REQUIRE( ws_message_details.m_opcode == opcode_t::text_frame );
 
 	REQUIRE( ws_message_details.payload_len() == 5 );
@@ -266,10 +266,10 @@ TEST_CASE( "Parse simple message (chunked)" , "[websocket][parser][read]" )
 
 	auto ws_message_details = parser.current_message();
 
-	REQUIRE( ws_message_details.m_final_flag == true );
-	REQUIRE( ws_message_details.m_rsv1_flag == false );
-	REQUIRE( ws_message_details.m_rsv2_flag == false );
-	REQUIRE( ws_message_details.m_rsv3_flag == false );
+	REQUIRE(ws_message_details.m_final_flag);
+	REQUIRE(!ws_message_details.m_rsv1_flag);
+	REQUIRE(!ws_message_details.m_rsv2_flag);
+	REQUIRE(!ws_message_details.m_rsv3_flag);
 	REQUIRE( ws_message_details.m_opcode == opcode_t::text_frame );
 
 	REQUIRE( ws_message_details.payload_len() == 5 );

--- a/dev/test/websocket/validators/main.cpp
+++ b/dev/test/websocket/validators/main.cpp
@@ -68,7 +68,7 @@ TEST_CASE(
 				0x21
 			}) };
 
-		REQUIRE( check_utf8_is_correct( str ) == true );
+		REQUIRE(check_utf8_is_correct(str));
 	}
 	{
 		std::string str{ to_char_each({
@@ -94,28 +94,28 @@ TEST_CASE(
 				0x64
 			}) };
 
-		REQUIRE( check_utf8_is_correct( str ) == false );
+		REQUIRE(!check_utf8_is_correct(str));
 	}
 	{
 		std::string str{ to_char_each({
 				0xf8, 0x88, 0x80, 0x80, 0x80
 			}) };
 
-		REQUIRE( check_utf8_is_correct( str ) == false );
+		REQUIRE(!check_utf8_is_correct(str));
 	}
 	{
 		std::string str{ to_char_each({
 				0xed, 0x9f, 0xbf
 			}) };
 
-		REQUIRE( check_utf8_is_correct( str ) == true );
+		REQUIRE(check_utf8_is_correct(str));
 	}
 	{
 		std::string str{ to_char_each({
 				0xf0, 0x90, 0x80, 0x80
 			}) };
 
-		REQUIRE( check_utf8_is_correct( str ) == true );
+		REQUIRE(check_utf8_is_correct(str));
 	}
 }
 

--- a/dev/test/websocket/ws_connection/main.cpp
+++ b/dev/test/websocket/ws_connection/main.cpp
@@ -12,7 +12,6 @@
 #include <restinio/websocket/websocket.hpp>
 #include <restinio/utils/base64.hpp>
 #include <restinio/utils/sha1.hpp>
-#include <restinio/websocket/impl/utf8.hpp>
 
 #include <test/common/utest_logger.hpp>
 #include <test/common/pub.hpp>


### PR DESCRIPTION
I've fixed various warning reported by clang-tidy in the sample and test folders only. And added add_package() command for http-parser when RESTINIO_FIND_DEPS is enabled. Testes everything on Windows with Visual Studio and Linux with GCC 9.2.