### PR TITLE
Fixed the build with asio-1.16 (boost-1.72.0).

### DIFF
--- a/dev/restinio/asio_include.hpp
+++ b/dev/restinio/asio_include.hpp
@@ -13,6 +13,9 @@
 // RESTinio uses stand-alone version of asio.
 #include <asio.hpp>
 
+// Define added to not have to distinguish between boost and non-boost asio in other code.
+#define RESTINIO_ASIO_VERSION ASIO_VERSION
+
 namespace restinio
 {
 	namespace asio_ns = ::asio;
@@ -56,6 +59,9 @@ namespace restinio
 
 // RESTinio uses boost::asio.
 #include <boost/asio.hpp>
+
+// Define added to not have to distinguish between boost and non-boost asio in other code.
+#define RESTINIO_ASIO_VERSION BOOST_ASIO_VERSION
 
 namespace restinio
 {

--- a/dev/restinio/impl/sendfile_operation_win.ipp
+++ b/dev/restinio/impl/sendfile_operation_win.ipp
@@ -19,7 +19,7 @@ namespace impl
 namespace asio_details
 {
 
-#if ASIO_VERSION < 101300
+#if RESTINIO_ASIO_VERSION < 101300
 
 template<typename Socket >
 decltype(auto)
@@ -138,8 +138,17 @@ class sendfile_operation_runner_t final
 
 	private:
 		std::unique_ptr< char[] > m_buffer{ new char [ this->m_chunk_size ] };
+		// Starting with asio-1.14.0 (boost-1.70.0) we must use executor_or_context_from_socket
+		// in order to get the io_context.
+#if RESTINIO_ASIO_VERSION >= 101400
+		asio_ns::windows::random_access_handle
+			m_file_handle{
+				asio_details::executor_or_context_from_socket(this->m_socket),
+				this->m_file_descriptor };
+#else
 		asio_ns::windows::random_access_handle
 			m_file_handle{ this->m_socket.get_executor().context(), this->m_file_descriptor };
+#endif
 
 		auto
 		make_async_read_some_at_handler() noexcept

--- a/dev/restinio/impl/tls_socket.hpp
+++ b/dev/restinio/impl/tls_socket.hpp
@@ -38,6 +38,10 @@ class tls_socket_t
 	public:
 		using socket_t = asio_ns::ssl::stream< asio_ns::ip::tcp::socket >;
 		using context_handle_t = std::shared_ptr< asio_ns::ssl::context >;
+		// Needed for asio >= 1.16.0 (starting with boost-1.72.0)
+#if RESTINIO_ASIO_VERSION >= 101600
+		using executor_type = asio_ns::executor;
+#endif
 		tls_socket_t( const tls_socket_t & ) = delete;
 		tls_socket_t & operator = ( const tls_socket_t & ) = delete;
 


### PR DESCRIPTION
* introduced RESTINIO_ASIO_VERSION define holding the asio version for
  standalone and boost versions of asio
* asio-1.16 uses a new way to get an io_context from a socket
* tls_socket_t needed a new typedef to be compatible with asio-1.16