### PR TITLE
adding a bearer auth parser

### DIFF
--- a/dev/restinio/helpers/http_field_parsers/bearer_auth.hpp
+++ b/dev/restinio/helpers/http_field_parsers/bearer_auth.hpp
@@ -1,0 +1,219 @@
+/*
+ * RESTinio
+ */
+
+/*!
+ * @file
+ * @brief Helpers for dealing with bearer authentification.
+ *
+ * @since v.0.6.7.1
+ */
+
+#pragma once
+
+#include <restinio/helpers/http_field_parsers/authorization.hpp>
+
+#include <restinio/utils/base64.hpp>
+
+#include <restinio/http_headers.hpp>
+#include <restinio/request_handler.hpp>
+#include <restinio/expected.hpp>
+
+#include <iostream>
+
+namespace restinio
+{
+
+namespace http_field_parsers
+{
+
+namespace bearer_auth
+{
+
+//
+// params_t
+//
+/*!
+ * @brief Parameters for bearer authentification.
+ *
+ * @since v.0.6.7.1
+ */
+struct params_t
+{
+	//! Unique ID for a client.
+	/*!
+	 * Can't be empty.
+	 */
+	std::string client_id;
+
+	//! Very Secret secret of a client.
+	/*!
+	 * Can't be empty.
+	 */
+	std::string client_secret;
+};
+
+//
+// extraction_error_t
+//
+/*!
+ * @brief Error codes for failures of extraction of bearer authentification
+ * parameters.
+ *
+ * @since v.0.6.7.1
+ */
+enum class extraction_error_t
+{
+	//! There is no HTTP field with authentification parameters.
+	no_auth_http_field,
+	
+	//! The HTTP field with authentification parameters can't be parsed.
+	illegal_http_field_value,
+
+	//! Different authentification scheme found.
+	//! bearer authentification scheme is expected.
+	not_bearer_auth_scheme,
+
+	//! Invalid value of parameter for bearer authentification scheme.
+	//! The single parameter in the form of token68 is expected.
+	invalid_bearer_auth_param,
+
+	//! Value of token68 parameter for bearer authentification can't be decoded.
+	token68_decode_error,
+
+	//! Wrong format for id:secret in decoded parameter.
+	//! Maybe there is no colon symbol.
+	invalid_id_secret_pair,
+
+	//! Empty id in id:secret pair.
+	empty_id,
+
+	//! Empty secret in id:secret pair.
+	empty_secret,
+};
+
+namespace impl
+{
+
+RESTINIO_NODISCARD
+inline expected_t< params_t, extraction_error_t >
+perform_extraction_attempt(
+	const optional_t< string_view_t > opt_field_value )
+{
+	if( !opt_field_value )
+		return make_unexpected( extraction_error_t::no_auth_http_field );
+
+	const auto field_value_parse_result = authorization_value_t::try_parse(
+			*opt_field_value );
+	if( !field_value_parse_result )
+		return make_unexpected( extraction_error_t::illegal_http_field_value );
+
+	const auto & parsed_value = *field_value_parse_result;
+	if( "bearer" != parsed_value.auth_scheme )
+		return make_unexpected( extraction_error_t::not_bearer_auth_scheme );
+
+	const auto * token68 = get_if<authorization_value_t::token68_t>(
+			&parsed_value.auth_param );
+	if( !token68 )
+		return make_unexpected( extraction_error_t::invalid_bearer_auth_param );
+
+	const auto unbase64_result =
+			restinio::utils::base64::try_decode( token68->value );
+	if( !unbase64_result )
+		return make_unexpected( extraction_error_t::token68_decode_error );
+
+	const std::string & id_secret = *unbase64_result;
+	const auto first_colon = id_secret.find( ':' );
+	if( std::string::npos == first_colon )
+		return make_unexpected(
+				extraction_error_t::invalid_id_secret_pair );
+	if( 0u == first_colon )
+		return make_unexpected( extraction_error_t::empty_id );
+	if( id_secret.length() == first_colon )
+		return make_unexpected( extraction_error_t::empty_secret );
+
+	return params_t{
+			id_secret.substr( 0u, first_colon ),
+			id_secret.substr( first_colon + 1u )
+	};
+}
+
+} /* namespace impl */
+
+//
+// try_extract_params
+//
+/*!
+ * @brief Helper function for getting parameters of bearer authentification
+ * from a request.
+ *
+ * This helper function is intended to be used for cases when authentification
+ * parameters are stored inside a HTTP-field with a custom name. For example:
+ * @code
+ * auto on_request(restinio::request_handle_t & req) {
+ * 	using namespace restinio::http_field_parsers::bearer_auth;
+ * 	const auto auth_params = try_extract_params(*req, "X-My-Authorization");
+ * 	if(auth_params) {
+ * 		const std::string & id = auth_params->id;
+ * 		const std::string & secret = auth_params->secret;
+ * 		... // Do something with id and secret.
+ * 	}
+ * 	...
+ * }
+ * @endcode
+ *
+ * @since v.0.6.7.1
+ */
+RESTINIO_NODISCARD
+inline expected_t< params_t, extraction_error_t >
+try_extract_params(
+	//! A request that should hold a HTTP-field with authentification
+	//! parameters.
+	const request_t & req,
+	//! The name of a HTTP-field with authentification parameters.
+	string_view_t auth_field_name )
+{
+	return impl::perform_extraction_attempt(
+			req.header().opt_value_of( auth_field_name ) );
+}
+
+/*!
+ * @brief Helper function for getting parameters of bearer authentification
+ * from a request.
+ *
+ * Usage example:
+ * @code
+ * auto on_request(restinio::request_handle_t & req) {
+ * 	using namespace restinio::http_field_parsers::bearer_auth;
+ * 	const auto auth_params = try_extract_params(
+ * 			*req, restinio::http_field::authorization);
+ * 	if(auth_params) {
+ * 		const std::string & id = auth_params->id;
+ * 		const std::string & secret = auth_params->secret;
+ * 		... // Do something with id and secret.
+ * 	}
+ * 	...
+ * }
+ * @endcode
+ *
+ * @since v.0.6.7.1
+ */
+RESTINIO_NODISCARD
+inline expected_t< params_t, extraction_error_t >
+try_extract_params(
+	//! A request that should hold a HTTP-field with authentification
+	//! parameters.
+	const request_t & req,
+	//! The ID of a HTTP-field with authentification parameters.
+	http_field_t auth_field_id )
+{
+	return impl::perform_extraction_attempt(
+			req.header().opt_value_of( auth_field_id ) );
+}
+
+} /* namespace bearer_auth */
+
+} /* namespace http_field_parsers */
+
+} /* namespace restinio */
+

--- a/dev/test/CMakeLists.txt
+++ b/dev/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_subdirectory(from_string)
 add_subdirectory(websocket)
 add_subdirectory(file_upload)
 add_subdirectory(basic_auth)
+add_subdirectory(bearer_auth)
 
 if ( OPENSSL_FOUND )
 	add_subdirectory(socket_options_tls)

--- a/dev/test/bearer_auth/CMakeLists.txt
+++ b/dev/test/bearer_auth/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(UNITTEST _unit.test.bearer_auth)
+include(${CMAKE_SOURCE_DIR}/cmake/unittest.cmake)
+

--- a/dev/test/bearer_auth/main.cpp
+++ b/dev/test/bearer_auth/main.cpp
@@ -1,0 +1,253 @@
+/*
+	restinio
+*/
+
+#include <catch2/catch.hpp>
+
+#include <restinio/helpers/http_field_parsers/bearer_auth.hpp>
+
+#include <test/common/dummy_connection.hpp>
+
+using namespace std::string_literals;
+
+RESTINIO_NODISCARD
+auto
+make_dummy_endpoint()
+{
+	return restinio::endpoint_t{
+			restinio::asio_ns::ip::address::from_string("127.0.0.1"),
+			12345u
+	};
+}
+
+TEST_CASE( "No Authorization field", "[bearer_auth]" )
+{
+	using namespace restinio::http_field_parsers::bearer_auth;
+
+	auto req = std::make_shared< restinio::request_t >(
+			restinio::request_id_t{1},
+			restinio::http_request_header_t{},
+			"Body"s,
+			dummy_connection_t::make(1u),
+			make_dummy_endpoint() );
+
+	const auto result = try_extract_params( *req,
+			restinio::http_field::authorization );
+
+	REQUIRE( !result );
+	REQUIRE( extraction_error_t::no_auth_http_field == result.error() );
+}
+
+TEST_CASE( "Empty Authorization field", "[bearer_auth]" )
+{
+	using namespace restinio::http_field_parsers::bearer_auth;
+
+	restinio::http_request_header_t dummy_header{
+			restinio::http_method_post(),
+			"/"
+	};
+	dummy_header.set_field(
+			restinio::http_field::authorization,
+			""s );
+
+	auto req = std::make_shared< restinio::request_t >(
+			restinio::request_id_t{1},
+			std::move(dummy_header),
+			"Body"s,
+			dummy_connection_t::make(1u),
+			make_dummy_endpoint() );
+
+	const auto result = try_extract_params( *req,
+			restinio::http_field::authorization );
+
+	REQUIRE( !result );
+	REQUIRE( extraction_error_t::illegal_http_field_value == result.error() );
+}
+
+TEST_CASE( "Different encoding scheme", "[bearer_auth]" )
+{
+	using namespace restinio::http_field_parsers::bearer_auth;
+
+	restinio::http_request_header_t dummy_header{
+			restinio::http_method_post(),
+			"/"
+	};
+	dummy_header.set_field(
+			restinio::http_field::authorization,
+			"MyScheme param=value, anotherparam=anothervalue"s );
+
+	auto req = std::make_shared< restinio::request_t >(
+			restinio::request_id_t{1},
+			std::move(dummy_header),
+			"Body"s,
+			dummy_connection_t::make(1u),
+			make_dummy_endpoint() );
+
+	const auto result = try_extract_params( *req,
+			restinio::http_field::authorization );
+
+	REQUIRE( !result );
+	REQUIRE( extraction_error_t::not_bearer_auth_scheme == result.error() );
+}
+
+TEST_CASE( "Wrong Bearer Authentification params", "[bearer_auth]" )
+{
+	using namespace restinio::http_field_parsers::bearer_auth;
+
+	restinio::http_request_header_t dummy_header{
+			restinio::http_method_post(),
+			"/"
+	};
+	dummy_header.set_field(
+			restinio::http_field::authorization,
+			"Bearer param=value, anotherparam=anothervalue"s );
+
+	auto req = std::make_shared< restinio::request_t >(
+			restinio::request_id_t{1},
+			std::move(dummy_header),
+			"Body"s,
+			dummy_connection_t::make(1u),
+			make_dummy_endpoint() );
+
+	const auto result = try_extract_params( *req,
+			restinio::http_field::authorization );
+
+	REQUIRE( !result );
+	REQUIRE( extraction_error_t::invalid_bearer_auth_param == result.error() );
+}
+
+TEST_CASE( "No semicolon in id:secret pair", "[bearer_auth]" )
+{
+	using namespace restinio::http_field_parsers::bearer_auth;
+
+	restinio::http_request_header_t dummy_header{
+			restinio::http_method_post(),
+			"/"
+	};
+	dummy_header.set_field(
+			restinio::http_field::authorization,
+			"Bearer dXNlcnBhc3N3b3Jk"s );
+
+	auto req = std::make_shared< restinio::request_t >(
+			restinio::request_id_t{1},
+			std::move(dummy_header),
+			"Body"s,
+			dummy_connection_t::make(1u),
+			make_dummy_endpoint() );
+
+	const auto result = try_extract_params( *req,
+			restinio::http_field::authorization );
+
+	REQUIRE( !result );
+	REQUIRE( extraction_error_t::invalid_id_secret_pair == result.error() );
+}
+
+TEST_CASE( "Empty id in id:secret pair", "[bearer_auth]" )
+{
+	using namespace restinio::http_field_parsers::bearer_auth;
+
+	restinio::http_request_header_t dummy_header{
+			restinio::http_method_post(),
+			"/"
+	};
+	dummy_header.set_field(
+			restinio::http_field::authorization,
+			"Bearer OnBhc3N3b3Jk"s );
+
+	auto req = std::make_shared< restinio::request_t >(
+			restinio::request_id_t{1},
+			std::move(dummy_header),
+			"Body"s,
+			dummy_connection_t::make(1u),
+			make_dummy_endpoint() );
+
+	const auto result = try_extract_params( *req,
+			restinio::http_field::authorization );
+
+	REQUIRE( !result );
+	REQUIRE( extraction_error_t::empty_id == result.error() );
+}
+
+TEST_CASE( "Empty secret in id:secret pair", "[bearer_auth]" )
+{
+	using namespace restinio::http_field_parsers::bearer_auth;
+
+	restinio::http_request_header_t dummy_header{
+			restinio::http_method_post(),
+			"/"
+	};
+	dummy_header.set_field(
+			restinio::http_field::authorization,
+			"Bearer dXNlcjo="s );
+
+	auto req = std::make_shared< restinio::request_t >(
+			restinio::request_id_t{1},
+			std::move(dummy_header),
+			"Body"s,
+			dummy_connection_t::make(1u),
+			make_dummy_endpoint() );
+
+	const auto result = try_extract_params( *req,
+			restinio::http_field::authorization );
+
+	REQUIRE( !result );
+	REQUIRE( extraction_error_t::empty_secret == result.error() );
+}
+
+
+TEST_CASE( "Valid Authorization field", "[bearer_auth]" )
+{
+	using namespace restinio::http_field_parsers::bearer_auth;
+
+	restinio::http_request_header_t dummy_header{
+			restinio::http_method_post(),
+			"/"
+	};
+	dummy_header.set_field(
+			restinio::http_field::authorization,
+			"Bearer dXNlcjoxMjM0"s );
+
+	auto req = std::make_shared< restinio::request_t >(
+			restinio::request_id_t{1},
+			std::move(dummy_header),
+			"Body"s,
+			dummy_connection_t::make(1u),
+			make_dummy_endpoint() );
+
+	const auto result = try_extract_params( *req,
+			restinio::http_field::authorization );
+
+	REQUIRE( result );
+	REQUIRE( "user" == result->id );
+	REQUIRE( "1234" == result->secret );
+}
+
+TEST_CASE( "Valid X-My-Authorization field", "[bearer_auth]" )
+{
+	using namespace restinio::http_field_parsers::bearer_auth;
+
+	restinio::http_request_header_t dummy_header{
+			restinio::http_method_post(),
+			"/"
+	};
+	dummy_header.set_field(
+			restinio::http_field::authorization,
+			"Bearer dXNlcjoxMjM0"s );
+	dummy_header.set_field(
+			"X-My-Authorization",
+			"Bearer bXktdXNlcjpteS0xMjM0"s );
+
+	auto req = std::make_shared< restinio::request_t >(
+			restinio::request_id_t{1},
+			std::move(dummy_header),
+			"Body"s,
+			dummy_connection_t::make(1u),
+			make_dummy_endpoint() );
+
+	const auto result = try_extract_params( *req,
+			"x-my-authorization" );
+
+	REQUIRE( result );
+	REQUIRE( "my-user" == result->id );
+	REQUIRE( "my-1234" == result->secret );
+}

--- a/dev/test/bearer_auth/prj.rb
+++ b/dev/test/bearer_auth/prj.rb
@@ -1,0 +1,17 @@
+require 'mxx_ru/cpp'
+require 'restinio/asio_helper.rb'
+
+MxxRu::Cpp::exe_target {
+
+	RestinioAsioHelper.attach_propper_asio( self )
+
+	required_prj 'nodejs/http_parser_mxxru/prj.rb'
+	required_prj 'fmt_mxxru/prj.rb'
+	required_prj 'restinio/platform_specific_libs.rb'
+	required_prj 'test/catch_main/prj.rb'
+
+	target( "_unit.test.bearer_auth" )
+
+	cpp_source( "main.cpp" )
+}
+

--- a/dev/test/bearer_auth/prj.ut.rb
+++ b/dev/test/bearer_auth/prj.ut.rb
@@ -1,0 +1,7 @@
+require 'mxx_ru/binary_unittest'
+
+Mxx_ru::setup_target(
+	Mxx_ru::Binary_unittest_target.new(
+		"test/bearer_auth/prj.ut.rb",
+		"test/bearer_auth/prj.rb" )
+)


### PR DESCRIPTION
When your code is **sooo** good it's this easy to expand! :heart: 

The only complication with this is the `token68` that's defined in [RFC 7235](https://tools.ietf.org/html/rfc7235#section-2.1) is, as far as i can tell, exactly the same as [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1) `b64token`. But the names are different :confounded: 

If there's any changes I should make to make this match your vision, I will be have happy to apply them.

PS: I have never figured out how to setup the project to run the unit tests, it's just copy paste so fingers crossed.