### PR TITLE
fmt 8.0.1 format string must be contexpr

### DIFF
--- a/dev/restinio/message_builders.hpp
+++ b/dev/restinio/message_builders.hpp
@@ -814,16 +814,23 @@ class response_builder_t< chunked_output_t > final
 						impl::content_length_field_presence_t::skip_content_length ) );
 			}
 
-			const char * format_string = "{:X}\r\n";
+			bool first = true;
 			for( auto & chunk : m_chunks )
-			{
-				bufs.emplace_back(
-					fmt::format(
-						format_string,
-						asio_ns::buffer_size( chunk.buf() ) ) );
-
-				// Now include "\r\n"-ending for a previous chunk to format string.
-				format_string = "\r\n{:X}\r\n";
+			{	
+				if ( first ) 
+				{
+					bufs.emplace_back(
+						fmt::format(
+							"{:X}\r\n", 
+							asio_ns::buffer_size(chunk.buf() ) ) );
+                            		first = false;
+				} else {
+					// Now include "\r\n"-ending for a previous chunk to format string.
+					bufs.emplace_back(
+						fmt::format(
+							"\r\n{:X}\r\n", 
+							asio_ns::buffer_size(chunk.buf() ) ) );
+				}
 
 				bufs.emplace_back( std::move( chunk ) );
 


### PR DESCRIPTION
I ran into an issue when building an application with restinio and fmt 8.0.1. 

The problem is that in version 8.0.1 fmt requires the format string to be constexpr. 

I had a short look and fixed it. 