### PR TITLE
Update path2regex (third time's the charm, hopefully.)

### DIFF
--- a/dev/restinio/path2regex/path2regex.hpp
+++ b/dev/restinio/path2regex/path2regex.hpp
@@ -714,7 +714,12 @@ inline lextokens_t lexer (string_view_t str) {
 			if (str.at(j) == '?')
 				throw exception_t("Pattern cannot start with '?' at pos " + std::to_string(j));
 			while (j < str.size()) {
-				if (str.at(j) == '\\') {
+				if (str.at(j) == '/') {
+
+					pattern.append("\\") += str.at(j++);
+					continue;
+				}
+				else if (str.at(j) == '\\') {
 					pattern += {str.at(j), str.at(j + 1)}; // string_view_lite doesn't let us use substr() to do this.
 					j+=2;
 					continue;

--- a/dev/test/router/express/additional_tests.ipp
+++ b/dev/test/router/express/additional_tests.ipp
@@ -96,7 +96,7 @@ TEST_CASE( "Invalid path" , "[path2regex][invalid]" )
 	}
 	catch( const restinio::exception_t & ex )
 	{
-		REQUIRE_THAT( ex.what(), Catch::Matchers::Contains( "pos 5:" ) );
+		REQUIRE_THAT( ex.what(), Catch::Matchers::Contains( "pos 5" ) );
 	}
 
 	try
@@ -106,7 +106,7 @@ TEST_CASE( "Invalid path" , "[path2regex][invalid]" )
 	}
 	catch( const restinio::exception_t & ex )
 	{
-		REQUIRE_THAT( ex.what(), Catch::Matchers::Contains( "pos 4:" ) );
+		REQUIRE_THAT( ex.what(), Catch::Matchers::Contains( "pos 4" ) );
 	}
 
 	try
@@ -116,7 +116,7 @@ TEST_CASE( "Invalid path" , "[path2regex][invalid]" )
 	}
 	catch( const restinio::exception_t & ex )
 	{
-		REQUIRE_THAT( ex.what(), Catch::Matchers::Contains( "pos 11:" ) );
+		REQUIRE_THAT( ex.what(), Catch::Matchers::Contains( "pos 11" ) );
 	}
 
 	try
@@ -126,7 +126,7 @@ TEST_CASE( "Invalid path" , "[path2regex][invalid]" )
 	}
 	catch( const restinio::exception_t & ex )
 	{
-		REQUIRE_THAT( ex.what(), Catch::Matchers::Contains( "pos 10:" ) );
+		REQUIRE_THAT( ex.what(), Catch::Matchers::Contains( "pos 10" ) );
 	}
 }
 

--- a/dev/test/router/express/original_tests_part2.ipp
+++ b/dev/test/router/express/original_tests_part2.ipp
@@ -335,7 +335,7 @@ TEST_CASE( "Original tests #25", "[path2regex][original][generated][n25]")
 
 // "/:test?-bar"
 // null
-// [["/-bar",["/-bar",null]],["/foo-bar",["/foo-bar","foo"]]]
+// [["/-bar", null], ["-bar",["-bar",null]],["/foo-bar",["/foo-bar","foo"]]]
 TEST_CASE( "Original tests #26", "[path2regex][original][generated][n26]")
 {
 	auto matcher_data =
@@ -354,8 +354,15 @@ TEST_CASE( "Original tests #26", "[path2regex][original][generated][n26]")
 		route_params_t params;
 
 		restinio::router::impl::target_path_holder_t target_path{ R"target(/-bar)target" };
+		REQUIRE_FALSE( rm.match_route( target_path, params ) );
+	}
+
+	{
+		route_params_t params;
+
+		restinio::router::impl::target_path_holder_t target_path{ R"target(-bar)target" };
 		REQUIRE( rm.match_route( target_path, params ) );
-		REQUIRE( params.match() == R"match(/-bar)match" );
+		REQUIRE( params.match() == R"match(-bar)match" );
 
 		REQUIRE( 1 == params.named_parameters_size() );
 		const auto & nps = restinio::router::impl::route_params_accessor_t::named_parameters( params );
@@ -392,7 +399,7 @@ TEST_CASE( "Original tests #26", "[path2regex][original][generated][n26]")
 
 // "/:test*-bar"
 // null
-// [["/-bar",["/-bar",null]],["/foo-bar",["/foo-bar","foo"]],["/foo/baz-bar",["/foo/baz-bar","foo/baz"]]]
+// [["/-bar", null], ["-bar",["-bar",null]],["/foo-bar",["/foo-bar","foo"]]]
 TEST_CASE( "Original tests #27", "[path2regex][original][generated][n27]")
 {
 	auto matcher_data =
@@ -411,8 +418,15 @@ TEST_CASE( "Original tests #27", "[path2regex][original][generated][n27]")
 		route_params_t params;
 
 		restinio::router::impl::target_path_holder_t target_path{ R"target(/-bar)target" };
+		REQUIRE_FALSE( rm.match_route( target_path, params ) );
+	}
+
+	{
+		route_params_t params;
+
+		restinio::router::impl::target_path_holder_t target_path{ R"target(-bar)target" };
 		REQUIRE( rm.match_route( target_path, params ) );
-		REQUIRE( params.match() == R"match(/-bar)match" );
+		REQUIRE( params.match() == R"match(-bar)match" );
 
 		REQUIRE( 1 == params.named_parameters_size() );
 		const auto & nps = restinio::router::impl::route_params_accessor_t::named_parameters( params );

--- a/dev/test/router/express/original_tests_part4.ipp
+++ b/dev/test/router/express/original_tests_part4.ipp
@@ -1,35 +1,35 @@
 
-// Test #60 skipped
+// Test #63 skipped
 // "/(.*)/"
 // null
 // [["/match/anything",["/match/anything","/match/anything"]]]
 
-// Test #61 skipped
+// Test #64 skipped
 // "/\\/(\\d+)/"
 // null
 // [["/abc",null],["/123",["/123","123"]]]
 
-// Test #62 skipped
+// Test #65 skipped
 // "/test,/\\/(\\d+)/"
 // null
 // [["/test",["/test",null]]]
 
-// Test #63 skipped
+// Test #66 skipped
 // "/:test(\\d+),/(.*)/"
 // null
 // [["/123",["/123","123",null]],["/abc",["/abc",null,"/abc"]]]
 
-// Test #64 skipped
+// Test #67 skipped
 // "/:test,/route/:test"
 // null
 // [["/test",["/test","test",null]],["/route/test",["/route/test",null,"test"]]]
 
-// Test #65 skipped
+// Test #68 skipped
 // "/^\\/([^\\/]+)$/,/^\\/route\\/([^\\/]+)$/"
 // null
 // [["/test",["/test","test",null]],["/route/test",["/route/test",null,"test"]]]
 
-// Test #66 skipped
+// Test #69 skipped
 // "/(?:.*)/"
 // null
 // [["/anything/you/want",["/anything/you/want"]]]
@@ -37,7 +37,7 @@
 // "/\\(testing\\)"
 // null
 // [["/testing",null],["/(testing)",["/(testing)"]]]
-TEST_CASE( "Original tests #67", "[path2regex][original][generated][n67]")
+TEST_CASE( "Original tests #70", "[path2regex][original][generated][n70]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -75,15 +75,14 @@ TEST_CASE( "Original tests #67", "[path2regex][original][generated][n67]")
 	}
 
 }
-
-// "/.+*?=^!:${}[]|"
+// "/.\+\*\?\{\}=^!\:$[]|"
 // null
-// [["/.+*?=^!:${}[]|",["/.+*?=^!:${}[]|"]]]
-TEST_CASE( "Original tests #68", "[path2regex][original][generated][n68]")
+// [["/.+*?{}=^!:$[]|",["/.+*?{}=^!:$[]|"]]]
+TEST_CASE( "Original tests #71", "[path2regex][original][generated][n71]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
-			R"route(/.+*?=^!:${}[]|)route",
+			R"route(/.\+\*\?\{\}=^!\:$[]|)route",
 			path2regex::options_t{} );
 
 	route_matcher_t
@@ -96,9 +95,9 @@ TEST_CASE( "Original tests #68", "[path2regex][original][generated][n68]")
 	{
 		route_params_t params;
 
-		restinio::router::impl::target_path_holder_t target_path{ R"target(/.+*?=^!:${}[]|)target" };
+		restinio::router::impl::target_path_holder_t target_path{ R"target(/.+*?{}=^!:$[]|)target" };
 		REQUIRE( rm.match_route( target_path, params ) );
-		REQUIRE( params.match() == R"match(/.+*?=^!:${}[]|)match" );
+		REQUIRE( params.match() == R"match(/.+*?{}=^!:$[]|)match" );
 
 		REQUIRE( 0 == params.named_parameters_size() );
 		const auto & nps = restinio::router::impl::route_params_accessor_t::named_parameters( params );
@@ -114,7 +113,7 @@ TEST_CASE( "Original tests #68", "[path2regex][original][generated][n68]")
 // "/test\\/:uid(u\\d+)?:cid(c\\d+)?"
 // null
 // [["/test",null],["/test/",["/test/",null,null]],["/test/u123",["/test/u123","u123",null]],["/test/c123",["/test/c123",null,"c123"]]]
-TEST_CASE( "Original tests #69", "[path2regex][original][generated][n69]")
+TEST_CASE( "Original tests #72", "[path2regex][original][generated][n72]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -203,14 +202,14 @@ TEST_CASE( "Original tests #69", "[path2regex][original][generated][n69]")
 
 }
 
-// "/(apple-)?icon-:res(\\d+).png"
+// "/{apple-}?icon-:res(\\d+).png"
 // null
-// [["/icon-240.png",["/icon-240.png",null,"240"]],["/apple-icon-240.png",["/apple-icon-240.png","apple-","240"]]]
-TEST_CASE( "Original tests #70", "[path2regex][original][generated][n70]")
+// [["/icon-240.png",["/icon-240.png","240"]],["/apple-icon-240.png",["/apple-icon-240.png","240"]]]
+TEST_CASE( "Original tests #73", "[path2regex][original][generated][n73]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
-			R"route(/(apple-)?icon-:res(\d+).png)route",
+			R"route(/{apple-}?icon-:res(\d+).png)route",
 			path2regex::options_t{} );
 
 	route_matcher_t
@@ -234,10 +233,9 @@ TEST_CASE( "Original tests #70", "[path2regex][original][generated][n70]")
 		REQUIRE( nps[0].first == R"key(res)key" );
 		REQUIRE( nps[0].second == R"value(240)value" );
 
-		REQUIRE( 1 == params.indexed_parameters_size() );
+		REQUIRE( 0 == params.indexed_parameters_size() );
 		const auto & ips = restinio::router::impl::route_params_accessor_t::indexed_parameters( params);
-		REQUIRE( 1 == ips.size() );
-		REQUIRE( ips.at( 0 ) == R"value()value" );
+		REQUIRE( ips.empty() );
 	}
 
 	{
@@ -254,10 +252,9 @@ TEST_CASE( "Original tests #70", "[path2regex][original][generated][n70]")
 		REQUIRE( nps[0].first == R"key(res)key" );
 		REQUIRE( nps[0].second == R"value(240)value" );
 
-		REQUIRE( 1 == params.indexed_parameters_size() );
+		REQUIRE( 0 == params.indexed_parameters_size() );
 		const auto & ips = restinio::router::impl::route_params_accessor_t::indexed_parameters( params);
-		REQUIRE( 1 == ips.size() );
-		REQUIRE( ips.at( 0 ) == R"value(apple-)value" );
+		REQUIRE( ips.empty() );
 	}
 
 }
@@ -265,7 +262,7 @@ TEST_CASE( "Original tests #70", "[path2regex][original][generated][n70]")
 // "/:foo/:bar"
 // null
 // [["/match/route",["/match/route","match","route"]]]
-TEST_CASE( "Original tests #71", "[path2regex][original][generated][n71]")
+TEST_CASE( "Original tests #74", "[path2regex][original][generated][n74]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -306,7 +303,7 @@ TEST_CASE( "Original tests #71", "[path2regex][original][generated][n71]")
 // "/:foo(test\\)/bar"
 // null
 // []
-TEST_CASE( "Original tests #72", "[path2regex][original][generated][n72]")
+TEST_CASE( "Original tests #75", "[path2regex][original][generated][n75]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -325,7 +322,7 @@ TEST_CASE( "Original tests #72", "[path2regex][original][generated][n72]")
 // "/:remote([\\w\\-\\.]+)/:user([\\w\\-]+)"
 // null
 // [["/endpoint/user",["/endpoint/user","endpoint","user"]],["/endpoint/user-name",["/endpoint/user-name","endpoint","user-name"]],["/foo.bar/user-name",["/foo.bar/user-name","foo.bar","user-name"]]]
-TEST_CASE( "Original tests #73", "[path2regex][original][generated][n73]")
+TEST_CASE( "Original tests #76", "[path2regex][original][generated][n76]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -410,7 +407,7 @@ TEST_CASE( "Original tests #73", "[path2regex][original][generated][n73]")
 // "/:foo\\?"
 // null
 // [["/route?",["/route?","route"]]]
-TEST_CASE( "Original tests #74", "[path2regex][original][generated][n74]")
+TEST_CASE( "Original tests #77", "[path2regex][original][generated][n77]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -448,7 +445,7 @@ TEST_CASE( "Original tests #74", "[path2regex][original][generated][n74]")
 // "/:foo+baz"
 // null
 // [["/foobaz",["/foobaz","foo"]],["/foo/barbaz",["/foo/barbaz","foo/bar"]],["/baz",null]]
-TEST_CASE( "Original tests #75", "[path2regex][original][generated][n75]")
+TEST_CASE( "Original tests #78", "[path2regex][original][generated][n78]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -509,14 +506,14 @@ TEST_CASE( "Original tests #75", "[path2regex][original][generated][n75]")
 
 }
 
-// "/:pre?baz"
+// "\\/:pre?baz"
 // null
 // [["/foobaz",["/foobaz","foo"]],["/baz",["/baz",null]]]
-TEST_CASE( "Original tests #76", "[path2regex][original][generated][n76]")
+TEST_CASE( "Original tests #79", "[path2regex][original][generated][n79]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
-			R"route(/:pre?baz)route",
+			R"route(\/:pre?baz)route",
 			path2regex::options_t{} );
 
 	route_matcher_t
@@ -569,7 +566,7 @@ TEST_CASE( "Original tests #76", "[path2regex][original][generated][n76]")
 // "/:foo\\(:bar?\\)"
 // null
 // [["/hello(world)",["/hello(world)","hello","world"]],["/hello()",["/hello()","hello",null]]]
-TEST_CASE( "Original tests #77", "[path2regex][original][generated][n77]")
+TEST_CASE( "Original tests #80", "[path2regex][original][generated][n80]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -632,7 +629,7 @@ TEST_CASE( "Original tests #77", "[path2regex][original][generated][n77]")
 // "/:postType(video|audio|text)(\\+.+)?"
 // null
 // [["/video",["/video","video",null]],["/video+test",["/video+test","video","+test"]],["/video+",null]]
-TEST_CASE( "Original tests #78", "[path2regex][original][generated][n78]")
+TEST_CASE( "Original tests #81", "[path2regex][original][generated][n81]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -695,10 +692,150 @@ TEST_CASE( "Original tests #78", "[path2regex][original][generated][n78]")
 
 }
 
+// "/:foo?/:bar?-ext"
+// null
+// [["/-ext", null], ["-ext", ["-ext", undefined, undefined]],
+// ["/foo-ext", ["/foo-ext", "foo", undefined]], ["/foo/bar-ext", ["/foo/bar-ext", "foo", "bar"],
+// ["/foo-ext", null]]
+TEST_CASE( "Original tests #82", "[path2regex][original][generated][n82]")
+{
+	auto matcher_data =
+		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
+			R"route(/:foo?/:bar?-ext)route",
+			path2regex::options_t{} );
+
+	route_matcher_t
+		rm{
+			http_method_get(),
+			std::move( matcher_data.m_regex ),
+			std::move( matcher_data.m_named_params_buffer ),
+			std::move( matcher_data.m_param_appender_sequence ) };
+
+	{
+		route_params_t params;
+
+		restinio::router::impl::target_path_holder_t target_path{ R"target(/-ext)target" };
+		REQUIRE_FALSE( rm.match_route( target_path, params ) );
+	}
+
+	{
+		route_params_t params;
+
+		restinio::router::impl::target_path_holder_t target_path{ R"target(-ext)target" };
+		REQUIRE( rm.match_route( target_path, params ) );
+		REQUIRE( params.match() == R"match(-ext)match" );
+
+		REQUIRE( 2 == params.named_parameters_size() );
+		const auto & nps = restinio::router::impl::route_params_accessor_t::named_parameters( params );
+		REQUIRE( 2 == nps.size() );
+		REQUIRE( nps[0].first == R"key(foo)key" );
+		REQUIRE( nps[0].second == R"value()value" );
+		REQUIRE( nps[1].first == R"key(bar)key" );
+		REQUIRE( nps[1].second == R"value()value" );
+
+		REQUIRE( 0 == params.indexed_parameters_size() );
+		const auto & ips = restinio::router::impl::route_params_accessor_t::indexed_parameters( params);
+		REQUIRE( 0 == ips.size() );
+	}
+
+	{
+		route_params_t params;
+
+		restinio::router::impl::target_path_holder_t target_path{ R"target(/foo/bar-ext)target" };
+		REQUIRE( rm.match_route( target_path, params ) );
+		REQUIRE( params.match() == R"match(/foo/bar-ext)match" );
+
+		REQUIRE( 2 == params.named_parameters_size() );
+		const auto & nps = restinio::router::impl::route_params_accessor_t::named_parameters( params );
+		REQUIRE( 2 == nps.size() );
+		REQUIRE( nps[0].first == R"key(foo)key" );
+		REQUIRE( nps[0].second == R"value(foo)value" );
+		REQUIRE( nps[1].first == R"key(bar)key" );
+		REQUIRE( nps[1].second == R"value(bar)value" );
+
+		REQUIRE( 0 == params.indexed_parameters_size() );
+		const auto & ips = restinio::router::impl::route_params_accessor_t::indexed_parameters( params);
+		REQUIRE( 0 == ips.size() );
+	}
+
+	{
+		route_params_t params;
+
+		restinio::router::impl::target_path_holder_t target_path{ R"target(/foo/-ext)target" };
+		REQUIRE_FALSE( rm.match_route( target_path, params ) );
+	}
+}
+
+// "/:required/:optional?-ext"
+// null
+// [["/foo-ext", ["/foo-ext", "foo" undefined]], ["/foo/bar-ext", ["/foo/bar-ext", foo, bar]],
+// ["/foo-ext", ["/foo-ext", "foo", undefined]], ["/foo/-ext", null]]
+TEST_CASE( "Original tests #83", "[path2regex][original][generated][n83]")
+{
+	auto matcher_data =
+		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
+			R"route(/:required/:optional?-ext)route",
+			path2regex::options_t{} );
+
+	route_matcher_t
+		rm{
+			http_method_get(),
+			std::move( matcher_data.m_regex ),
+			std::move( matcher_data.m_named_params_buffer ),
+			std::move( matcher_data.m_param_appender_sequence ) };
+
+	{
+		route_params_t params;
+
+		restinio::router::impl::target_path_holder_t target_path{ R"target(/foo-ext)target" };
+		REQUIRE( rm.match_route( target_path, params ) );
+		REQUIRE( params.match() == R"match(/foo-ext)match" );
+
+		REQUIRE( 2 == params.named_parameters_size() );
+		const auto & nps = restinio::router::impl::route_params_accessor_t::named_parameters( params );
+		REQUIRE( 2 == nps.size() );
+		REQUIRE( nps[0].first == R"key(required)key" );
+		REQUIRE( nps[0].second == R"value(foo)value" );
+		REQUIRE( nps[1].first == R"key(optional)key" );
+		REQUIRE( nps[1].second == R"value()value" );
+
+		REQUIRE( 0 == params.indexed_parameters_size() );
+		const auto & ips = restinio::router::impl::route_params_accessor_t::indexed_parameters( params);
+		REQUIRE( 0 == ips.size() );
+	}
+
+	{
+		route_params_t params;
+
+		restinio::router::impl::target_path_holder_t target_path{ R"target(/foo/bar-ext)target" };
+		REQUIRE( rm.match_route( target_path, params ) );
+		REQUIRE( params.match() == R"match(/foo/bar-ext)match" );
+
+		REQUIRE( 2 == params.named_parameters_size() );
+		const auto & nps = restinio::router::impl::route_params_accessor_t::named_parameters( params );
+		REQUIRE( 2 == nps.size() );
+		REQUIRE( nps[0].first == R"key(required)key" );
+		REQUIRE( nps[0].second == R"value(foo)value" );
+		REQUIRE( nps[1].first == R"key(optional)key" );
+		REQUIRE( nps[1].second == R"value(bar)value" );
+
+		REQUIRE( 0 == params.indexed_parameters_size() );
+		const auto & ips = restinio::router::impl::route_params_accessor_t::indexed_parameters( params);
+		REQUIRE( 0 == ips.size() );
+	}
+
+	{
+		route_params_t params;
+
+		restinio::router::impl::target_path_holder_t target_path{ R"target(/foo/-ext)target" };
+		REQUIRE_FALSE( rm.match_route( target_path, params ) );
+	}
+}
+
 // "/:foo"
 // null
 // [["/café",["/café","café"]]]
-TEST_CASE( "Original tests #79", "[path2regex][original][generated][n79]")
+TEST_CASE( "Original tests #84", "[path2regex][original][generated][n84]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(

--- a/dev/test/router/express/original_tests_part5.ipp
+++ b/dev/test/router/express/original_tests_part5.ipp
@@ -2,7 +2,7 @@
 // "/café"
 // null
 // [["/café",["/café"]]]
-TEST_CASE( "Original tests #80", "[path2regex][original][generated][n80]")
+TEST_CASE( "Original tests #85", "[path2regex][original][generated][n85]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -37,7 +37,7 @@ TEST_CASE( "Original tests #80", "[path2regex][original][generated][n80]")
 // "packages/"
 // null
 // [["packages",null],["packages/",["packages/"]]]
-TEST_CASE( "Original tests #81", "[path2regex][original][generated][n81]")
+TEST_CASE( "Original tests #86", "[path2regex][original][generated][n86]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -79,7 +79,7 @@ TEST_CASE( "Original tests #81", "[path2regex][original][generated][n81]")
 // ":domain.com"
 // {"delimiter":"."}
 // [["example.com",["example.com","example"]],["github.com",["github.com","github"]]]
-TEST_CASE( "Original tests #82", "[path2regex][original][generated][n82]")
+TEST_CASE( "Original tests #87", "[path2regex][original][generated][n87")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -136,7 +136,7 @@ TEST_CASE( "Original tests #82", "[path2regex][original][generated][n82]")
 // "mail.:domain.com"
 // {"delimiter":"."}
 // [["mail.example.com",["mail.example.com","example"]],["mail.github.com",["mail.github.com","github"]]]
-TEST_CASE( "Original tests #83", "[path2regex][original][generated][n83]")
+TEST_CASE( "Original tests #88", "[path2regex][original][generated][n88]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -193,7 +193,7 @@ TEST_CASE( "Original tests #83", "[path2regex][original][generated][n83]")
 // "example.:ext"
 // {"delimiter":"."}
 // [["example.com",["example.com","com"]],["example.org",["example.org","org"]]]
-TEST_CASE( "Original tests #84", "[path2regex][original][generated][n84]")
+TEST_CASE( "Original tests #89", "[path2regex][original][generated][n89]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -250,7 +250,7 @@ TEST_CASE( "Original tests #84", "[path2regex][original][generated][n84]")
 // "this is"
 // {"delimiter":" ","end":false}
 // [["this is a test",["this is"]],["this isn't",null]]
-TEST_CASE( "Original tests #85", "[path2regex][original][generated][n85]")
+TEST_CASE( "Original tests #90", "[path2regex][original][generated][n90]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -292,7 +292,7 @@ TEST_CASE( "Original tests #85", "[path2regex][original][generated][n85]")
 // "/test"
 // {"endsWith":"?"}
 // [["/test",["/test"]],["/test?query=string",["/test"]],["/test/?query=string",["/test/"]],["/testx",null]]
-TEST_CASE( "Original tests #86", "[path2regex][original][generated][n86]")
+TEST_CASE( "Original tests #91", "[path2regex][original][generated][91]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -366,7 +366,7 @@ TEST_CASE( "Original tests #86", "[path2regex][original][generated][n86]")
 // "/test"
 // {"endsWith":"?","strict":true}
 // [["/test?query=string",["/test"]],["/test/?query=string",null]]
-TEST_CASE( "Original tests #87", "[path2regex][original][generated][n87]")
+TEST_CASE( "Original tests #92", "[path2regex][original][generated][92]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(
@@ -408,7 +408,7 @@ TEST_CASE( "Original tests #87", "[path2regex][original][generated][n87]")
 // "$:foo$:bar?"
 // {"delimiters":"$"}
 // [["$x",["$x","x",null]],["$x$y",["$x$y","x","y"]]]
-TEST_CASE( "Original tests #88", "[path2regex][original][generated][n88]")
+TEST_CASE( "Original tests #93", "[path2regex][original][generated][n93]")
 {
 	auto matcher_data =
 		path2regex::path2regex< restinio::router::impl::route_params_appender_t, regex_engine_t >(


### PR DESCRIPTION
I've corrected several errors in my port of the newer javascript code. Behavior should now be identical to `path-regexp@6.2.0`; and I've updated the test suite to reflect this.

There's still going to be breaking changes for some people, but they'll likely be things `path-to-regexp` itself already had a while ago. Not all of these have yet made it into express.js, though., given that the 5.0 betas depend on `path-to-regexp 3.2.0` 

From documentation of path-to-regexp, main changes are (most are copied from the path-to-regexp release notes):

This time around, I tested it using C++14, and all tests were passing.

1. Allow empty string with `ending: false` to match both relative and absolute paths
2. Use delimiter when processing repeated matching groups (e.g. `foo/bar` has no prefix, but has a delimiter)
3. Support `starting` option to disable anchoring from beginning of the string
4. Various enhancements from path-to-regexp 6.0, which are intended partly to restore some compatibility with older versions:
    - Support for nested non-capturing groups in regexp, e.g. `/(abc(?=d))`
    - Support for custom prefix and suffix groups using `/{abc(.*)def}`
    - Tokens in an unexpected position will throw an error:
        - Paths like `/test(foo` previously worked treating ( as a literal character, now it expects ( to be closed and is treated as a group
        - You can escape the character for the previous behavior, e.g. `/test\(foo`
5. Support custom `prefixes` (same as `delimiters` in RESTinio) option (default is `/.` which acts like every version since 0.x again)
6. Add support for `{}` to capture prefix/suffix explicitly, enables custom use-cases like `/:attr1{-:attr2}?`
7. Use `/#?` as default (end)`delimiter` to avoid matching on query or fragment parameters; if you are matching non-paths (e.g. hostnames), you can set `delimiter`to `.`
8. Fix invalid matching of :name* parameter

I've updated the test suite to reflect the changes, as well as added some new tests that had been added to the upstream `path-to-regexp` as well.