### PR TITLE
Fix zlip decompressing for some cases.

### DIFF
--- a/dev/restinio/transforms/zlib.hpp
+++ b/dev/restinio/transforms/zlib.hpp
@@ -833,7 +833,7 @@ class zlib_t
 					continue;
 				}
 
-				if( 0 == m_zlib_stream.avail_in )
+				if( 0 == m_zlib_stream.avail_in || Z_STREAM_END == operation_result)
 				{
 					// All the input was consumed.
 					break;


### PR DESCRIPTION
Hi.
zlib doc says inflate returns Z_STREAM_END if the end of the compressed data has
  been reached and all uncompressed output has been produced (https://github.com/madler/zlib/blob/master/zlib.h#L503). It means we can finish decompressing and break the loop even we still have input data ( avail_in is not zero ). In other case we get infinite loop when decompressing is finished but input buffer is not empty.

Thank you.