### PR TITLE
Switch to Boost 1.88.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
         uses: MarkusJx/install-boost@v2.5.0
         id: install-boost
         with:
-            boost_version: 1.87.0
+            boost_version: 1.88.0
             boost_install_dir: ${{github.workspace}}/local_boost
             toolset: ${{ matrix.build_settings.toolset }}
             platform_version: 24.04


### PR DESCRIPTION
Upon checking [MarkusJx/install-boost@v2.5.0](https://github.com/MarkusJx/prebuilt-boost/blob/6a129c5a2742fb0d0834ff0e439f0e7877488a37/versions-manifest.json) (main branch at the moment of this commit) 
there is no entry with `Boost 1.87.0` + `ubuntu 24.04`. On the other hand entry 1.88.0+24.04 exists.

This PR solve CI fails to obtain Boost.