### PR TITLE
Fix sendfile operation on macos

### DIFF
--- a/dev/restinio/impl/connection.hpp
+++ b/dev/restinio/impl/connection.hpp
@@ -1325,9 +1325,9 @@ class connection_t final
 						// the lambda because lambda object itself will be
 						// destroyed.
 						auto op_ctx_reseter = restinio::utils::at_scope_exit(
-								[&op_ctx] {
+								[op_ctx_copy = op_ctx] () mutable {
 									// Reset sendfile operation context.
-									RESTINIO_ENSURE_NOEXCEPT_CALL( op_ctx.reset() );
+									RESTINIO_ENSURE_NOEXCEPT_CALL( op_ctx_copy.reset() );
 								} );
 
 						if( !ec )


### PR DESCRIPTION
Make sure `op_ctx` tis doing reset at a scope exit receives own independent object to call reset on it. 

I'm not sure of the exact cause but maybe LLVM on macos takes a different approach handling lifetime of the object captured when lambda finishes it's scope. Copying the context object to reset lambda capture does the job regardless of lifetime of initial context object.