### PR TITLE
Respect SIGTERM signal for server shutdown by default

### DIFF
--- a/dev/restinio/http_server_run.hpp
+++ b/dev/restinio/http_server_run.hpp
@@ -229,7 +229,7 @@ run(
 
 	std::exception_ptr exception_caught;
 
-	asio_ns::signal_set break_signals{ server.io_context(), SIGINT };
+	asio_ns::signal_set break_signals{ server.io_context(), SIGINT, SIGTERM };
 	break_signals.async_wait(
 		[&]( const asio_ns::error_code & ec, int ){
 			if( !ec )
@@ -313,7 +313,7 @@ run(
 
 	std::exception_ptr exception_caught;
 
-	asio_ns::signal_set break_signals{ server.io_context(), SIGINT };
+	asio_ns::signal_set break_signals{ server.io_context(), SIGINT, SIGTERM };
 	break_signals.async_wait(
 		[&]( const asio_ns::error_code & ec, int ){
 			if( !ec )
@@ -523,7 +523,7 @@ run_with_break_signal_handling(
 {
 	std::exception_ptr exception_caught;
 
-	asio_ns::signal_set break_signals{ server.io_context(), SIGINT };
+	asio_ns::signal_set break_signals{ server.io_context(), SIGINT, SIGTERM };
 	break_signals.async_wait(
 		[&]( const asio_ns::error_code & ec, int ){
 			if( !ec )

--- a/dev/sample/using_external_io_context/main.cpp
+++ b/dev/sample/using_external_io_context/main.cpp
@@ -54,7 +54,7 @@ int main()
 				.address( "localhost" )
 				.request_handler( create_request_handler( "server2" ) ) };
 
-		asio_ns::signal_set break_signals{ io_context, SIGINT };
+		asio_ns::signal_set break_signals{ io_context, SIGINT, SIGTERM };
 		break_signals.async_wait(
 			[&]( const asio_ns::error_code & ec, int ){
 				if( !ec )


### PR DESCRIPTION
This fixes server is not being shutdown automatically on SIGTERM by default.
For example, docker down sends SIGTERM for the graceful shutdown.