### PR TITLE
Fix include error in websocket\message.hpp

### DIFF
--- a/dev/restinio/websocket/message.hpp
+++ b/dev/restinio/websocket/message.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 
 #include <restinio/utils/impl/bitops.hpp>
+#include <restinio/string_view.hpp>
 
 namespace restinio
 {


### PR DESCRIPTION
See issue #242 about the compiler error that this fixes when only the websocket\websocket.hpp header is included.